### PR TITLE
Fix tests using a node

### DIFF
--- a/config/blockchain.js
+++ b/config/blockchain.js
@@ -10,32 +10,17 @@ module.exports = {
     wsOrigins: "auto",  // Origins from which to accept websockets requests
                         // When set to "auto", Embark will automatically set the cors to the address of the webserver
     wsHost: "localhost", // WS-RPC server listening interface (default: "localhost")
-    wsPort: 8546 // WS-RPC server listening port (default: 8546)
+    wsPort: 8546, // WS-RPC server listening port (default: 8546)
 
     // Accounts to use as node accounts
     // The order here corresponds to the order of `web3.eth.getAccounts`, so the first one is the `defaultAccount`
-    /*,accounts: [
+    accounts: [
       {
         nodeAccounts: true, // Accounts use for the node
-        numAddresses: "1", // Number of addresses/accounts (defaults to 1)
-        password: "config/development/devpassword" // Password file for the accounts
-      },
-      // Below are additional accounts that will count as `nodeAccounts` in the `deployment` section of your contract config
-      // Those will not be unlocked in the node itself
-      {
-        privateKey: "your_private_key"
-      },
-      {
-        privateKeyFile: "path/to/file", // Either a keystore or a list of keys, separated by , or ;
-        password: "passwordForTheKeystore" // Needed to decrypt the keystore file
-      },
-      {
-        mnemonic: "12 word mnemonic",
-        addressIndex: "0", // Optionnal. The index to start getting the address
-        numAddresses: "1", // Optionnal. The number of addresses to get
-        hdpath: "m/44'/60'/0'/0/" // Optionnal. HD derivation path
+        numAddresses: 2, // Number of addresses/accounts (defaults to 1)
+        password: "config/development/password" // Password file for the accounts
       }
-    ]*/
+    ]
   },
 
   // default environment, merges with the settings in default

--- a/test/escrow_spec.js
+++ b/test/escrow_spec.js
@@ -1,4 +1,4 @@
-// /*global contract, config, it, assert*/
+/*global contract, config, it, assert, embark, web3*/
 const TestUtils = require("../utils/testUtils");
 
 const License = embark.require('Embark/contracts/License');
@@ -19,7 +19,7 @@ config({
   accounts = web3_accounts;
 });
 
-contract("Escrow", function () {
+contract("Escrow", function() {
   const {toBN} = web3.utils;
   const expirationTime = parseInt((new Date()).getTime() / 1000, 10) + 3600;
   const value = web3.utils.toWei("0.1", "ether");
@@ -29,12 +29,12 @@ contract("Escrow", function () {
   this.timeout(0);
 
 
-  it("Non-seller must not be able to create escrows", async() => {
+  it("Non-seller must not be able to create escrows", async () => {
     try {
       await Escrow.methods.create(accounts[1], expirationTime).send({from: accounts[0], value});
       assert.fail('should have reverted before');
-    } catch(error) {
-        TestUtils.assertJump(error);
+    } catch (error) {
+      TestUtils.assertJump(error);
     }
   });
 
@@ -48,7 +48,7 @@ contract("Escrow", function () {
     const created = receipt.events.Created;
 
     assert(!!created, "Created() not triggered");
-    
+
     assert.equal(created.returnValues.seller, accounts[0], "Invalid seller");
     assert.equal(created.returnValues.buyer, accounts[1], "Invalid buyer");
     assert.equal(created.returnValues.amount, value, "Invalid amount");
@@ -70,27 +70,27 @@ contract("Escrow", function () {
     assert.equal(escrow.released, false, "Should not be released");
     assert.equal(escrow.canceled, false, "Should not be canceled");
   });
-  
-  
-  it("An invalid escrow cannot be released", async() => {
+
+
+  it("An invalid escrow cannot be released", async () => {
     try {
       await Escrow.methods.release(999).send({from: accounts[0]}); // Invalid escrow
       assert.fail('should have reverted before');
-    } catch(error) {
-        TestUtils.assertJump(error);
+    } catch (error) {
+      TestUtils.assertJump(error);
     }
   });
-  
+
 
   it("Accounts different from the escrow owner cannot release an escrow", async () => {
     try {
       await Escrow.methods.release(0).send({from: accounts[1]}); // Buyer tries to release
       assert.fail('should have reverted before');
-    } catch(error) {
-        TestUtils.assertJump(error);
+    } catch (error) {
+      TestUtils.assertJump(error);
     }
   });
-  
+
 
   it("Escrow owner can release his funds to the buyer", async () => {
     const buyerBalanceBeforeEscrow = await web3.eth.getBalance(accounts[1]);
@@ -106,18 +106,18 @@ contract("Escrow", function () {
   });
 
 
-  it("Accounts different from the escrow owner cannot cancel escrows", async() => {
+  it("Accounts different from the escrow owner cannot cancel escrows", async () => {
     receipt = await Escrow.methods.create(accounts[1], expirationTime).send({from: accounts[0], value: "1"});
     escrowId = receipt.events.Created.returnValues.escrowId;
 
     try {
       receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[1]}); // Buyer tries to cancel
       assert.fail('should have reverted before');
-    } catch(error) {
-        TestUtils.assertJump(error);
+    } catch (error) {
+      TestUtils.assertJump(error);
     }
   });
-   
+
 
   it("A seller can cancel their escrows", async () => {
     receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[0]});
@@ -131,17 +131,17 @@ contract("Escrow", function () {
   });
 
 
-  it("An escrow can only be canceled once", async() => {
+  it("An escrow can only be canceled once", async () => {
     try {
       receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[0]});
       assert.fail('should have reverted before');
-    } catch(error) {
-        TestUtils.assertJump(error);
+    } catch (error) {
+      TestUtils.assertJump(error);
     }
   });
 
 
-  it("Released escrow cannot be released again", async() => {
+  it("Released escrow cannot be released again", async () => {
     receipt = await Escrow.methods.create(accounts[1], expirationTime).send({from: accounts[0], value: "1"});
     escrowId = receipt.events.Created.returnValues.escrowId;
 
@@ -150,13 +150,13 @@ contract("Escrow", function () {
     try {
       receipt = await Escrow.methods.release(escrowId).send({from: accounts[0]});
       assert.fail('should have reverted before');
-    } catch(error) {
-        TestUtils.assertJump(error);
+    } catch (error) {
+      TestUtils.assertJump(error);
     }
   });
 
 
-  it("Released escrow cannot be canceled", async() => {
+  it("Released escrow cannot be canceled", async () => {
     receipt = await Escrow.methods.create(accounts[1], expirationTime).send({from: accounts[0], value: "1"});
 
     escrowId = receipt.events.Created.returnValues.escrowId;
@@ -166,13 +166,13 @@ contract("Escrow", function () {
     try {
       receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[0]});
       assert.fail('should have reverted before');
-    } catch(error) {
-        TestUtils.assertJump(error);
+    } catch (error) {
+      TestUtils.assertJump(error);
     }
   });
 
-  
-  it("Canceled escrow cannot be released", async() => {
+
+  it("Canceled escrow cannot be released", async () => {
     receipt = await Escrow.methods.create(accounts[1], expirationTime).send({from: accounts[0], value: "1"});
 
     escrowId = receipt.events.Created.returnValues.escrowId;
@@ -182,13 +182,13 @@ contract("Escrow", function () {
     try {
       receipt = await Escrow.methods.release(escrowId).send({from: accounts[0]});
       assert.fail('should have reverted before');
-    } catch(error) {
-        TestUtils.assertJump(error);
+    } catch (error) {
+      TestUtils.assertJump(error);
     }
   });
 
 
-  it("Expired escrow cannot be released", async() => {
+  it("Expired escrow cannot be released", async () => {
     receipt = await Escrow.methods.create(accounts[1], expirationTime).send({from: accounts[0], value: "1"});
 
     escrowId = receipt.events.Created.returnValues.escrowId;
@@ -198,17 +198,17 @@ contract("Escrow", function () {
     try {
       receipt = await Escrow.methods.release(escrowId).send({from: accounts[0]});
       assert.fail('should have reverted before');
-    } catch(error) {
-        TestUtils.assertJump(error);
+    } catch (error) {
+      TestUtils.assertJump(error);
     }
   });
 
 
-  it("Paused contract allows withdrawal by owner only on active escrows", async() => {
+  it("Paused contract allows withdrawal by owner only on active escrows", async () => {
     const expirationTime = parseInt((new Date()).getTime() / 1000, 10) + 10000;
-   
+
     receipt = await Escrow.methods.create(accounts[1], expirationTime).send({from: accounts[0], value: "1"});
-    
+
     const releasedEscrowId = receipt.events.Created.returnValues.escrowId;
 
     await Escrow.methods.release(releasedEscrowId).send({from: accounts[0]});
@@ -220,8 +220,8 @@ contract("Escrow", function () {
     try {
       receipt = await Escrow.methods.withdraw_emergency(escrowId).send({from: accounts[0]});
       assert.fail('should have reverted before');
-    } catch(error) {
-        TestUtils.assertJump(error);
+    } catch (error) {
+      TestUtils.assertJump(error);
     }
 
     receipt = await Escrow.methods.pause().send({from: accounts[0]});
@@ -233,8 +233,8 @@ contract("Escrow", function () {
     try {
       receipt = await Escrow.methods.withdraw_emergency(releasedEscrowId).send({from: accounts[0]});
       assert.fail('should have reverted before');
-    } catch(error) {
-        TestUtils.assertJump(error);
+    } catch (error) {
+      TestUtils.assertJump(error);
     }
 
     receipt = await Escrow.methods.withdraw_emergency(escrowId).send({from: accounts[0]});

--- a/test/license_spec.js
+++ b/test/license_spec.js
@@ -9,15 +9,15 @@ const zeroAddress = "0x0000000000000000000000000000000000000000";
 config({
   contracts: {
     License: {
-      args: [ zeroAddress, 1 ]
-    },
+      args: [zeroAddress, 1]
+    }
   }
 }, (_err, web3_accounts) => {
-  accounts = web3_accounts
+  accounts = web3_accounts;
 });
 
-contract("License", function () {
-  it("should set recipient and price on instantiation", async function () {
+contract("License", function() {
+  it("should set recipient and price on instantiation", async function() {
     const recipient = await License.methods.getRecipient().call();
     const price = await License.methods.getPrice().call();
     assert.strictEqual(parseInt(price, 10), 1);
@@ -25,15 +25,15 @@ contract("License", function () {
   });
 
 
-  it("should not allow to buy license when price is incorrect", async function () {
+  it("should not allow to buy license when price is incorrect", async function() {
     try {
       await License.methods.buy().send({value: 2, from: accounts[0]});
-    } catch(error) {
-      assert.strictEqual(error.message, "VM Exception while processing transaction: revert Value is not equal to expected price");
+    } catch (error) {
+      assert.ok(error.message.indexOf('revert') > -1);
     }
   });
 
-  it("should allow to buy license", async function () {
+  it("should allow to buy license", async function() {
     let isLicenseOwner = await License.methods.isLicenseOwner(accounts[0]).call();
     assert.strictEqual(isLicenseOwner, false);
     await License.methods.buy().send({value: 1, from: accounts[0]});
@@ -41,37 +41,37 @@ contract("License", function () {
     assert.strictEqual(isLicenseOwner, true);
   });
 
-  it("should not allow to buy license when the address already owns one", async function () {
+  it("should not allow to buy license when the address already owns one", async function() {
     try {
       await License.methods.buy().send({value: 1, from: accounts[0]});
-    } catch(error) {
-      assert.strictEqual(error.message, "VM Exception while processing transaction: revert License already bought");
+    } catch (error) {
+      assert.ok(error.message.indexOf('revert') > -1);
     }
   });
 
-  it("should not allow to set the price if not the owner", async function () {
+  it("should not allow to set the price if not the owner", async function() {
     try {
       await License.methods.setPrice(10).send({from: accounts[1]});
-    } catch(error) {
-      assert.strictEqual(error.message, "VM Exception while processing transaction: revert");
+    } catch (error) {
+      assert.ok(error.message.indexOf('revert') > -1);
     }
   });
 
-  it("should allow to set the price if owner", async function () {
+  it("should allow to set the price if owner", async function() {
     await License.methods.setPrice(10).send({from: accounts[0]});
     const price = await License.methods.getPrice().call();
     assert.strictEqual(parseInt(price, 10), 10);
   });
 
-  it("should not allow set the recipient if not the owner", async function () {
+  it("should not allow set the recipient if not the owner", async function() {
     try {
       await License.methods.setRecipient(accounts[1]).send({from: accounts[1]});
-    } catch(error) {
-      assert.strictEqual(error.message, "VM Exception while processing transaction: revert");
+    } catch (error) {
+      assert.ok(error.message.indexOf('revert') > -1);
     }
   });
 
-  it("should allow to set the recipient if owner", async function () {
+  it("should allow to set the recipient if owner", async function() {
     await License.methods.setRecipient(accounts[0]).send({from: accounts[0]});
     const recipient = await License.methods.getRecipient().call();
     assert.strictEqual(recipient, accounts[0]);

--- a/utils/testUtils.js
+++ b/utils/testUtils.js
@@ -1,47 +1,47 @@
+/*global assert, web3*/
 
 // This has been tested with the real Ethereum network and Testrpc.
 // Copied and edited from: https://gist.github.com/xavierlepretre/d5583222fde52ddfbc58b7cfa0d2d0a9
 exports.assertReverts = (contractMethodCall, maxGasAvailable) => {
   return new Promise((resolve, reject) => {
-      try {
-          resolve(contractMethodCall())
-      } catch (error) {
-          reject(error)
-      }
+    try {
+      resolve(contractMethodCall());
+    } catch (error) {
+      reject(error);
+    }
   })
-      .then(tx => {
-          assert.equal(tx.receipt.gasUsed, maxGasAvailable, "tx successful, the max gas available was not consumed")
-      })
-      .catch(error => {
-          if ((error + "").indexOf("invalid opcode") < 0 && (error + "").indexOf("out of gas") < 0) {
-              // Checks if the error is from TestRpc. If it is then ignore it.
-              // Otherwise relay/throw the error produced by the above assertion.
-              // Note that no error is thrown when using a real Ethereum network AND the assertion above is true.
-              throw error
-          }
-      })
-}
+    .then(tx => {
+      assert.equal(tx.receipt.gasUsed, maxGasAvailable, "tx successful, the max gas available was not consumed");
+    })
+    .catch(error => {
+      if ((String(error)).indexOf("invalid opcode") < 0 && (String(error)).indexOf("out of gas") < 0) {
+        // Checks if the error is from TestRpc. If it is then ignore it.
+        // Otherwise relay/throw the error produced by the above assertion.
+        // Note that no error is thrown when using a real Ethereum network AND the assertion above is true.
+        throw error;
+      }
+    });
+};
 
 exports.listenForEvent = event => new Promise((resolve, reject) => {
   event({}, (error, response) => {
-      if (!error) {
-          resolve(response.args)
-      } else {
-          reject(error)
-      }
-      event.stopWatching()
-  })
+    if (!error) {
+      resolve(response.args);
+    } else {
+      reject(error);
+    }
+    event.stopWatching();
+  });
 });
 
 exports.eventValues = (receipt, eventName) => {
-  if(receipt.events[eventName])
-      return receipt.events[eventName].returnValues;
-}
+  if (receipt.events[eventName]) return receipt.events[eventName].returnValues;
+};
 
 exports.addressToBytes32 = (address) => {
   const stringed = "0000000000000000000000000000000000000000000000000000000000000000" + address.slice(2);
-  return "0x" + stringed.substring(stringed.length - 64, stringed.length); 
-}
+  return "0x" + stringed.substring(stringed.length - 64, stringed.length);
+};
 
 
 // OpenZeppelin's expectThrow helper -
@@ -69,74 +69,72 @@ exports.expectThrow = async promise => {
 };
 
 
-
 exports.assertJump = (error) => {
   assert(error.message.search('revert') > -1, 'Revert should happen');
-}
-
-
-var callbackToResolve = function (resolve, reject) {
-  return function (error, value) {
-          if (error) {
-              reject(error);
-          } else {
-              resolve(value);
-          }
-      };
 };
+
+
+function callbackToResolve(resolve, reject) {
+  return function(error, value) {
+    if (error) {
+      reject(error);
+    } else {
+      resolve(value);
+    }
+  };
+}
 
 exports.promisify = (func) =>
   (...args) => {
-      return new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const callback = (err, data) => err ? reject(err) : resolve(data);
       func.apply(this, [...args, callback]);
-      });
-  }
-      
+    });
+  };
+
 
 // This has been tested with the real Ethereum network and Testrpc.
 // Copied and edited from: https://gist.github.com/xavierlepretre/d5583222fde52ddfbc58b7cfa0d2d0a9
 exports.assertReverts = (contractMethodCall, maxGasAvailable) => {
   return new Promise((resolve, reject) => {
-      try {
-          resolve(contractMethodCall())
-      } catch (error) {
-          reject(error)
-      }
+    try {
+      resolve(contractMethodCall());
+    } catch (error) {
+      reject(error);
+    }
   })
-      .then(tx => {
-          assert.equal(tx.receipt.gasUsed, maxGasAvailable, "tx successful, the max gas available was not consumed")
-      })
-      .catch(error => {
-          if ((error + "").indexOf("invalid opcode") < 0 && (error + "").indexOf("out of gas") < 0) {
-              // Checks if the error is from TestRpc. If it is then ignore it.
-              // Otherwise relay/throw the error produced by the above assertion.
-              // Note that no error is thrown when using a real Ethereum network AND the assertion above is true.
-              throw error
-          }
-      })
-}
+    .then(tx => {
+      assert.equal(tx.receipt.gasUsed, maxGasAvailable, "tx successful, the max gas available was not consumed");
+    })
+    .catch(error => {
+      if ((String(error)).indexOf("invalid opcode") < 0 && (String(error)).indexOf("out of gas") < 0) {
+        // Checks if the error is from TestRpc. If it is then ignore it.
+        // Otherwise relay/throw the error produced by the above assertion.
+        // Note that no error is thrown when using a real Ethereum network AND the assertion above is true.
+        throw error;
+      }
+    });
+};
 
 exports.listenForEvent = event => new Promise((resolve, reject) => {
   event({}, (error, response) => {
-      if (!error) {
-          resolve(response.args)
-      } else {
-          reject(error)
-      }
-      event.stopWatching()
-  })
+    if (!error) {
+      resolve(response.args);
+    } else {
+      reject(error);
+    }
+    event.stopWatching();
+  });
 });
 
 exports.eventValues = (receipt, eventName) => {
-  if(receipt.events[eventName])
-      return receipt.events[eventName].returnValues;
-}
+  if (receipt.events[eventName]) return receipt.events[eventName].returnValues;
+};
 
 exports.addressToBytes32 = (address) => {
   const stringed = "0000000000000000000000000000000000000000000000000000000000000000" + address.slice(2);
-  return "0x" + stringed.substring(stringed.length - 64, stringed.length); 
-}
+  return "0x" + stringed.substring(stringed.length - 64, stringed.length);
+};
 
 
 // OpenZeppelin's expectThrow helper -
@@ -165,26 +163,16 @@ exports.expectThrow = async promise => {
 
 exports.assertJump = (error) => {
   assert(error.message.search('revert') > -1, 'Revert should happen');
-}
-
-var callbackToResolve = function (resolve, reject) {
-  return function (error, value) {
-          if (error) {
-              reject(error);
-          } else {
-              resolve(value);
-          }
-      };
 };
 
 exports.promisify = (func) =>
   (...args) => {
-      return new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const callback = (err, data) => err ? reject(err) : resolve(data);
       func.apply(this, [...args, callback]);
-      });
-  }
-  
+    });
+  };
+
 exports.zeroAddress = '0x0000000000000000000000000000000000000000';
 exports.zeroBytes32 = "0x0000000000000000000000000000000000000000000000000000000000000000";
 exports.timeUnits = {
@@ -194,7 +182,7 @@ exports.timeUnits = {
   days: 24 * 60 * 60,
   weeks: 7 * 24 * 60 * 60,
   years: 365 * 24 * 60 * 60
-}
+};
 
 exports.ensureException = function(error) {
   assert(isException(error), error.toString());
@@ -207,33 +195,37 @@ function isException(error) {
 
 exports.increaseTime = async (amount) => {
   return new Promise(function(resolve, reject) {
-    web3.currentProvider.sendAsync(
+    const sendMethod = (web3.currentProvider.sendAsync) ? web3.currentProvider.sendAsync.bind(web3.currentProvider) : web3.currentProvider.send.bind(web3.currentProvider);
+    sendMethod(
       {
         jsonrpc: '2.0',
         method: 'evm_increaseTime',
-        params: [+amount],
+        params: [Number(amount)],
         id: new Date().getSeconds()
       },
-      async (error) => {
+      (error) => {
+        console.log('Finsihed the first', error);
         if (error) {
           console.log(error);
-          return reject(err);
+          return reject(error);
         }
-        await web3.currentProvider.sendAsync(
-          {
-            jsonrpc: '2.0',
-            method: 'evm_mine',
-            params: [],
-            id: new Date().getSeconds()
-          }, (error) => {
-            if (error) {
-              console.log(error);
-              return reject(err);
-            }
-            resolve();
-          }
-        )
+        resolve();
+        // sendMethod(
+        //   {
+        //     jsonrpc: '2.0',
+        //     method: 'evm_mine',
+        //     params: [],
+        //     id: new Date().getSeconds()
+        //   }, (error) => {
+        //     console.log('Got the otehr', error);
+        //     if (error) {
+        //       console.log(error);
+        //       return reject(error);
+        //     }
+        //     resolve();
+        //   }
+        // );
       }
-    )
+    );
   });
-}
+};


### PR DESCRIPTION
Using  `embark test --node=embark` wa sbroken, because:

1. The tests needed at least two accounts, so I added another one in the blockchain config
2. The revert error message is not the same for the VM and the real node
3. The provider function is not the same for the vm and the real node

also a bit of auto indents and linting