### PR TITLE
fix(accounts): add node accounts as first accounts so that they work in the dapp

### DIFF
--- a/config/contracts.js
+++ b/config/contracts.js
@@ -89,6 +89,9 @@ module.exports = {
       // The order here corresponds to the order of `web3.eth.getAccounts`, so the first one is the `defaultAccount`
       accounts: [
         {
+          nodeAccounts: true,
+        },
+        {
           mnemonic: "foster gesture flock merge beach plate dish view friend leave drink valley shield list enemy",
           balance: "5 ether",
           numAddresses: "10",


### PR DESCRIPTION
Basically, we have address for deployement that used to be coming from the mnemonic and we gave it SNT, but in the Dapp, we use the node's account and it has 0. Now, the first account is the node's.

Tell me if this breaks something (is there a reason why we would need to use the custom address as deployment)