### PR TITLE
fix(filter-menu): fix filter menu close glitches

### DIFF
--- a/app/js/components/Buyer/SorterFilter.jsx
+++ b/app/js/components/Buyer/SorterFilter.jsx
@@ -12,47 +12,49 @@ import {Typeahead} from "react-bootstrap-typeahead";
 const FilterMenu = (props) => (
   <Fragment>
     <div className={classnames({"filter-menu-backdrop": true, "open": props.open})} onClick={props.close}/>
-    <div className={classnames({"filter-menu": true, "open": props.open})}>
-      <h4>Sort and filter</h4>
+    <div className={classnames("filter-menu", {"open": props.open})}>
+      <div className="filter-menu-content">
+        <h4>Sort and filter</h4>
 
-      <h5 className="mt-4">Sort</h5>
-      <ButtonGroup vertical className="w-100">
-        <CheckButton active={true}>
-          Top rated
-        </CheckButton>
-        <CheckButton active={false}>
-          Most recent
-        </CheckButton>
-      </ButtonGroup>
-
-      <h5 className="mt-4">Payment method</h5>
-      <ButtonGroup vertical className="w-100">
-        {props.paymentMethods.map((paymentMethod, index) => (
-          <CheckButton key={index}
-                       onClick={() => props.setPaymentMethodFilter(index)}
-                       active={index === props.paymentMethodFilter}>
-            {paymentMethod}
+        <h5 className="mt-4">Sort</h5>
+        <ButtonGroup vertical className="w-100">
+          <CheckButton active={true}>
+            Top rated
           </CheckButton>
-        ))}
-      </ButtonGroup>
+          <CheckButton active={false}>
+            Most recent
+          </CheckButton>
+        </ButtonGroup>
 
-      <h5 className="mt-4">Country</h5>
-      <FormGroup>
-        <Typeahead
-          options={['Canada', 'USA', 'France']}
-          placeholder={'Select'}
-        />
-      </FormGroup>
+        <h5 className="mt-4">Payment method</h5>
+        <ButtonGroup vertical className="w-100">
+          {props.paymentMethods.map((paymentMethod, index) => (
+            <CheckButton key={index}
+                         onClick={() => props.setPaymentMethodFilter(index)}
+                         active={index === props.paymentMethodFilter}>
+              {paymentMethod}
+            </CheckButton>
+          ))}
+        </ButtonGroup>
 
-      <h5 className="mt-4">Asset</h5>
-      <FormGroup>
-        <Typeahead
-          options={props.tokens.map((token) => ({value: token.address, label: token.symbol}))}
-          placeholder={'Select'}
-          value={props.tokenFilter}
-          onChange={props.setTokenFilter}
-        />
-      </FormGroup>
+        <h5 className="mt-4">Country</h5>
+        <FormGroup>
+          <Typeahead
+            options={['Canada', 'USA', 'France']}
+            placeholder={'Select'}
+          />
+        </FormGroup>
+
+        <h5 className="mt-4">Asset</h5>
+        <FormGroup>
+          <Typeahead
+            options={props.tokens.map((token) => ({value: token.address, label: token.symbol}))}
+            placeholder={'Select'}
+            value={props.tokenFilter}
+            onChange={props.setTokenFilter}
+          />
+        </FormGroup>
+      </div>
     </div>
   </Fragment>
 );

--- a/app/js/components/Buyer/SorterFilter.scss
+++ b/app/js/components/Buyer/SorterFilter.scss
@@ -21,43 +21,39 @@
   &.open {
     display: block;
   }
-
-  .filter-menu {
-    position: fixed;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    width: 0;
-    max-width: 350px;
-    background-color: white;
-    transition: width 0.5s ease;
-    padding: 24px 16px;
-  }
 }
 
-
+$filter-menu-padding-x: 3%;
+$menu-width: 85%;
 .filter-menu {
   position: fixed;
   right: 0;
   top: 0;
   bottom: 0;
   width: 0;
-  max-width: 500px;
+  max-width: 400px;
   background-color: white;
-  transition: width 0.5s ease;
   z-index: 9000;
-  padding: 0;
+  padding: 24px 0;
   overflow: hidden;
+  transition: width 0.5s, padding 0.5s;
 
   &.open {
-    width: 85%;
-    padding: 24px 16px;
+    width: $menu-width;
+    padding: 24px $filter-menu-padding-x;
 
     .btn {
       .fa-check {
         display: inline-block;
       }
     }
+  }
+
+  .filter-menu-content {
+    width: $menu-width - ($filter-menu-padding-x * 2);
+    overflow: hidden;
+    position: fixed;
+    max-width: 340px;
   }
 
   .btn {


### PR DESCRIPTION
Fixes some weird behaviours the filtyer menu had when closing.
It's still not perfect on browser, because on opening the menu will bounce a little bit, but on mobile it doesn't happen. (it's because we use percentage width and padding, but then we hit the max width so it bounces back to the max.