### PR TITLE
feat: display escrows in dispute for arbiters

### DIFF
--- a/app/css/bootstrap-overrides.scss
+++ b/app/css/bootstrap-overrides.scss
@@ -82,3 +82,28 @@ $input-icon-height: 20px;
   padding: 11px 36px;
 }
 
+
+.arbiterLabel {
+  border: 2px solid rgba(0, 0, 0, 0.1);
+  border-radius: 140px;
+  font-family: Inter;
+  font-size: 10px;
+  text-transform: uppercase;
+  position: relative;
+  display: block;
+  margin: -14px auto 10px auto;
+  width: 73px;
+  background: #fff;
+  padding: 3px;
+}
+
+.topCircle {
+  z-index: 90;
+  position: relative;
+}
+
+.bottomCircle {
+  z-index: 80;
+  position: relative;
+  left: -10px;
+}

--- a/app/css/bootstrap-overrides.scss
+++ b/app/css/bootstrap-overrides.scss
@@ -81,29 +81,3 @@ $input-icon-height: 20px;
 .btn {
   padding: 11px 36px;
 }
-
-
-.arbiterLabel {
-  border: 2px solid rgba(0, 0, 0, 0.1);
-  border-radius: 140px;
-  font-family: Inter;
-  font-size: 10px;
-  text-transform: uppercase;
-  position: relative;
-  display: block;
-  margin: -14px auto 10px auto;
-  width: 73px;
-  background: #fff;
-  padding: 3px;
-}
-
-.topCircle {
-  z-index: 90;
-  position: relative;
-}
-
-.bottomCircle {
-  z-index: 80;
-  position: relative;
-  left: -10px;
-}

--- a/app/js/components/UserInformation/index.jsx
+++ b/app/js/components/UserInformation/index.jsx
@@ -5,28 +5,30 @@ import Blockies from 'react-blockies';
 import Reputation from "../Reputation";
 import Address from './Address';
 
-const UserInformation = ({address, username, reputation}) => (
+const UserInformation = ({address, username, reputation, isArbitrator}) => (
   <Row className="border rounded py-4 m-0 text-center shadow-sm">
     <Col xs="12">
       <Blockies seed={address} className="rounded-circle border" scale={8}/>
+      {isArbitrator && <span className="arbiterLabel">Arbiter</span>}
     </Col>
-    <Col xs="12">
+    { !isArbitrator && <Col xs="12">
       <h4 className="font-weight-bold">{username}</h4>
-    </Col>
+    </Col>}
     <Col xs="12">
       <p className="text-muted">
         <Address address={address}/>
       </p>
     </Col>
-    <Col xs="12">
+    { !isArbitrator && <Col xs="12">
       <Reputation reputation={reputation}/>
-    </Col>
+    </Col>}
   </Row>);
 
 UserInformation.propTypes = {
   address: PropTypes.string,
   username: PropTypes.string,
-  reputation: PropTypes.object
+  reputation: PropTypes.object,
+  isArbitrator: PropTypes.bool
 };
 
 export default UserInformation;

--- a/app/js/features/arbitration/saga.js
+++ b/app/js/features/arbitration/saga.js
@@ -1,4 +1,5 @@
 import Escrow from 'Embark/contracts/Escrow';
+import MetadataStore from 'Embark/contracts/MetadataStore';
 
 import {fork, takeEvery, call, put} from 'redux-saga/effects';
 import {
@@ -22,7 +23,16 @@ export function *doGetEscrows() {
     const escrows = [];
     for (let i = 0; i < escrowIds.length; i++) {
       const escrow = yield call(Escrow.methods.transactions(escrowIds[i]).call);
+      const buyerId = yield MetadataStore.methods.addressToUser(escrow.buyer).call();
+      const buyer = yield MetadataStore.methods.users(buyerId).call();
+      const offer = yield MetadataStore.methods.offers(escrow.offerId).call();
+      const sellerId = yield MetadataStore.methods.addressToUser(offer.owner).call();
+      const seller = yield MetadataStore.methods.users(sellerId).call();
+      
       escrow.escrowId = escrowIds[i];
+      escrow.seller = offer.owner;
+      escrow.buyerInfo = buyer;
+      escrow.sellerInfo = seller;
       escrow.arbitration = yield call(Escrow.methods.arbitrationCases(escrowIds[i]).call);
       escrows.push(escrow);
     }

--- a/app/js/features/escrow/selectors.js
+++ b/app/js/features/escrow/selectors.js
@@ -7,7 +7,7 @@ export const getCreateEscrowStatus = state => state.escrow.createEscrowStatus;
 export const getTrades = (state, offerIds) => {
   const escrows = state.escrow.escrows[offerIds] || [];
   return escrows.map((escrow) => {
-    const offer = getOfferById(state, escrow.offerId);   
+    const offer = getOfferById(state, escrow.offerId);
     return {
       ...escrow,
       status: getTradeStatus(escrow),

--- a/app/js/features/escrow/selectors.js
+++ b/app/js/features/escrow/selectors.js
@@ -7,7 +7,7 @@ export const getCreateEscrowStatus = state => state.escrow.createEscrowStatus;
 export const getTrades = (state, offerIds) => {
   const escrows = state.escrow.escrows[offerIds] || [];
   return escrows.map((escrow) => {
-    const offer = getOfferById(state, escrow.offerId);
+    const offer = getOfferById(state, escrow.offerId);   
     return {
       ...escrow,
       status: getTradeStatus(escrow),

--- a/app/js/locales/en.json
+++ b/app/js/locales/en.json
@@ -77,6 +77,11 @@
     "noRating": "No rating available yet",
     "buying": "Buying License"
   },
+  "disputes": {
+    "noRecords": "No records available yet",
+    "openedDisputes": "Opened disputes",
+    "resolvedDisputes": "Resolved disputes"
+  },
   "map": {
     "loading": "Loading...",
     "denied": "You denied access to your position. We do not store that information, it is only to position you the following map."

--- a/app/js/pages/Home/index.jsx
+++ b/app/js/pages/Home/index.jsx
@@ -6,6 +6,8 @@ import { Link } from "react-router-dom";
 import { withNamespaces } from 'react-i18next';
 
 import license from "../../features/license";
+import network from "../../features/network";
+import metadata from "../../features/metadata";
 
 import "./index.scss";
 
@@ -19,6 +21,7 @@ class Home extends Component {
   }
 
   render() {
+    const isArbitrator = this.props.profile && this.props.profile.isArbitrator;
     const t = this.props.t;
     return (
       <div className="home">
@@ -34,14 +37,14 @@ class Home extends Component {
           </Col>
         </Row>
 
-        <Row className="home--footer">
+        {!isArbitrator && <Row className="home--footer">
           <Col xs={6}>
             <Button tag={Link} color="primary" block to="/offers/list">{t('home.buy')}</Button>
           </Col>
           <Col xs={6}>
             <Button tag={Link} color="primary" block to={this.sellUrl()}>{t('home.sell')}</Button>
           </Col>
-        </Row>
+        </Row>}
       </div>
     );
   }
@@ -50,12 +53,19 @@ class Home extends Component {
 Home.propTypes = {
   t: PropTypes.func,
   checkLicenseOwner: PropTypes.func,
-  isLicenseOwner: PropTypes.bool
+  isLicenseOwner: PropTypes.bool,
+  profile: PropTypes.object
 };
 
-const mapStateToProps = state => ({
-  isLicenseOwner: license.selectors.isLicenseOwner(state)
-});
+
+const mapStateToProps = (state) => {
+  const address = network.selectors.getAddress(state) || '';
+  return {
+    address,
+    isLicenseOwner: license.selectors.isLicenseOwner(state),
+    profile: metadata.selectors.getProfile(state, address)
+  };
+};
 
 export default connect(
   mapStateToProps,

--- a/app/js/pages/MyProfile/components/Disputes.jsx
+++ b/app/js/pages/MyProfile/components/Disputes.jsx
@@ -1,0 +1,55 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {Card} from 'reactstrap';
+import {withNamespaces} from 'react-i18next';
+import Blockies from 'react-blockies';
+
+class Disputes extends Component {
+  renderTrades() {
+    return (
+        this.props.disputes.map((dispute, index) => <Card key={index} body className="py-2 px-3 mb-3 shadow-sm">
+          <div className="d-flex my-1">
+            <span className="flex-fill align-self-center">
+              <Blockies seed={dispute.buyer} className="align-middle rounded-circle topCircle"/>
+              <Blockies seed={dispute.seller} className="align-middle rounded-circle bottomCircle"/>
+              <span className="ml-2">{dispute.buyerInfo.username} & {dispute.sellerInfo.username}</span>
+            </span>
+            <span className="flex-fill align-self-center text-right">
+              {this.props.showDate && 'TODO'}
+            </span>
+          </div>
+          </Card>
+        )
+    );
+  }
+
+  renderEmpty() {
+    const {t} = this.props;
+    return (
+      <Card body className="text-center">
+        {t("disputes.noRecords")}
+      </Card>
+    );
+  }
+
+  render() {
+    const {t, disputes, open} = this.props;
+    return (
+      <div className="mt-3">
+        <div>
+          <h3 className="d-inline-block">{open ? t("disputes.openedDisputes") : t("disputes.resolvedDisputes")}</h3>
+        </div>
+        {disputes.length === 0 ? this.renderEmpty(t) : this.renderTrades()}
+      </div>
+    );
+  }
+}
+
+Disputes.propTypes = {
+  t: PropTypes.func,
+  disputes: PropTypes.array,
+  showDate: PropTypes.bool,
+  open: PropTypes.bool
+};
+
+export default withNamespaces()(Disputes);

--- a/app/js/pages/MyProfile/index.jsx
+++ b/app/js/pages/MyProfile/index.jsx
@@ -5,10 +5,12 @@ import { connect } from 'react-redux';
 import metadata from '../../features/metadata';
 import network from '../../features/network';
 import escrow from '../../features/escrow';
+import arbitration from '../../features/arbitration';
 
 import UserInformation from '../../components/UserInformation';
 import Trades from './components/Trades';
 import Offers from './components/Offers';
+import Disputes from './components/Disputes';
 import StatusContactCode from './components/StatusContactCode';
 import { zeroAddress } from '../../utils/address';
 
@@ -22,16 +24,25 @@ const NULL_PROFILE = {
 class MyProfile extends Component {
   componentDidMount() {
     this.props.loadProfile(this.props.address);
+    this.props.getDisputedEscrows();
   }
 
   render() {
     const profile = this.props.profile;
     return (
       <Fragment>
-        <UserInformation reputation={profile.reputation} address={profile.address} username={profile.username}/>
-        <Trades trades={this.props.trades}/>
-        <Offers offers={profile.offers} location={profile.location} />
-        {profile.username.length > 0 && <StatusContactCode value={profile.statusContactCode} />}
+        <UserInformation isArbitrator={profile.isArbitrator} reputation={profile.reputation} address={profile.address} username={profile.username}/>
+        
+        {profile.isArbitrator && <Fragment>
+          <Disputes disputes={this.props.disputes.filter(x => x.arbitration.open)} open={true} showDate={true} />
+          <Disputes disputes={this.props.disputes.filter(x => !x.arbitration.open)} open={false} showDate={false} />
+        </Fragment>}
+
+        { !profile.isArbitrator && <Fragment>
+          <Trades trades={this.props.trades}/>
+          <Offers offers={profile.offers} location={profile.location} />
+          {profile.username && <StatusContactCode value={profile.statusContactCode} />}
+        </Fragment> }
       </Fragment>
     );
   }
@@ -41,7 +52,9 @@ MyProfile.propTypes = {
   address: PropTypes.string,
   profile: PropTypes.object,
   trades: PropTypes.array,
-  loadProfile: PropTypes.func
+  disputes: PropTypes.array,
+  loadProfile: PropTypes.func,
+  getDisputedEscrows: PropTypes.func
 };
 
 const mapStateToProps = state => {
@@ -50,7 +63,8 @@ const mapStateToProps = state => {
   return {
     address,
     profile,
-    trades: escrow.selectors.getTrades(state, profile.offers.map(offer => offer.id))
+    trades: escrow.selectors.getTrades(state, profile.offers.map(offer => offer.id)),
+    disputes: arbitration.selectors.escrows(state)
   };
 };
 
@@ -58,5 +72,6 @@ const mapStateToProps = state => {
 export default connect(
   mapStateToProps,
   {
-    loadProfile: metadata.actions.load
+    loadProfile: metadata.actions.load,
+    getDisputedEscrows: arbitration.actions.getDisputedEscrows
   })(MyProfile);

--- a/app/js/pages/MyProfile/index.jsx
+++ b/app/js/pages/MyProfile/index.jsx
@@ -14,6 +14,8 @@ import Disputes from './components/Disputes';
 import StatusContactCode from './components/StatusContactCode';
 import { zeroAddress } from '../../utils/address';
 
+import "./index.scss";
+
 const NULL_PROFILE = {
   address: zeroAddress,
   username: '',

--- a/app/js/pages/MyProfile/index.scss
+++ b/app/js/pages/MyProfile/index.scss
@@ -1,0 +1,25 @@
+
+.arbiterLabel {
+  border: 2px solid rgba(0, 0, 0, 0.1);
+  border-radius: 140px;
+  font-family: Inter;
+  font-size: 10px;
+  text-transform: uppercase;
+  position: relative;
+  display: block;
+  margin: -14px auto 10px auto;
+  width: 73px;
+  background: #fff;
+  padding: 3px;
+}
+
+.topCircle {
+  z-index: 90;
+  position: relative;
+}
+
+.bottomCircle {
+  z-index: 80;
+  position: relative;
+  left: -10px;
+}


### PR DESCRIPTION
Display escrows in dispute in the profile for Arbiters, and also hide/show buy and sell button for this role.

Design has a Date for open disputes, however, this information is not stored in the contract. (It's currently marked as "TODO"). **A decision must be made on this regard.**

To see the arbitration profile,  you must call `setArbitrator(_addr)` in the contract explorer of Embark Cockpit

