### PR TITLE
fix(escrow): get correct buyer info by fixing address used

### DIFF
--- a/src/js/features/escrow/saga.js
+++ b/src/js/features/escrow/saga.js
@@ -147,7 +147,7 @@ export function *doLoadEscrows({address}) {
       escrow.offer = yield MetadataStore.methods.offer(escrow.offerId).call();
       const sellerId = yield MetadataStore.methods.addressToUser(escrow.offer.owner).call();
       escrow.seller = yield MetadataStore.methods.users(sellerId).call();
-      const buyerId = yield MetadataStore.methods.addressToUser(address).call();
+      const buyerId = yield MetadataStore.methods.addressToUser(escrow.buyer).call();
       escrow.buyerInfo = yield MetadataStore.methods.users(buyerId).call();
       return escrow;
     }));


### PR DESCRIPTION
This caused an issue on the profile where the seller name was always displayed instead of the buyer one (when on the seller's profile)