### PR TITLE
Remove min max limits on Buy

### DIFF
--- a/src/js/wizards/Buy/1_Trade/index.jsx
+++ b/src/js/wizards/Buy/1_Trade/index.jsx
@@ -107,8 +107,8 @@ class Trade extends Component {
         return (
           <OfferTrade statusContactCode={this.props.offer.user.statusContactCode}
                       name={this.props.offer.user.username}
-                      minFIAT={200}
-                      maxFIAT={600}
+                      minFIAT={0} // TODO put here real values when we have it set in the contract
+                      maxFIAT={999999}
                       price={this._calcPrice()}
                       asset={this.props.offer.token.symbol}
                       currency={{id: this.props.offer.currency}}


### PR DESCRIPTION
For now, set limits from 0 to 999999 so that we can test however we want.

We'll just need to pass the real values once we have them in the contract