### PR TITLE
Fix getting 404 on reloading a wizard page

### DIFF
--- a/src/js/layout/App.jsx
+++ b/src/js/layout/App.jsx
@@ -1,6 +1,6 @@
 /*global web3*/
 import React, {Component} from 'react';
-import {HashRouter, Route, Redirect, Switch} from "react-router-dom";
+import {HashRouter, Route, Switch} from "react-router-dom";
 import {connect} from 'react-redux';
 import {Container} from 'reactstrap';
 import PropTypes from 'prop-types';
@@ -127,13 +127,11 @@ class App extends Component {
               ]}/>
             }
 
-            <Route path="/404" component={fourOFour}/>
-
             <Route path="/tmp/escrows" component={EscrowsContainer}/>
             <Route path="/tmp/signature" component={SignatureContainer}/>
             <Route path="/tmp/arbitration" component={ArbitrationContainer}/>
 
-            <Redirect to="/404"/>
+            <Route component={fourOFour}/>
           </Switch>
           </div>
         </Container>


### PR DESCRIPTION
This was caused by the `<Redirect>` tag applying before the Wizard route being rendered or something.

So now uses the fallback mechanism of the `<Switch>` to go to 404 instead. Only downside is that it won't show `/404` but the page will be the right one anyway.