### PR TITLE
Improve state management of escrows

### DIFF
--- a/contracts/teller-network/Escrow.sol
+++ b/contracts/teller-network/Escrow.sol
@@ -67,7 +67,7 @@ contract Escrow is Pausable, MessageSigned, Fees, Arbitrable {
     event Released(uint escrowId, uint date);
     event Canceled(uint escrowId, uint date);
     event Rating(uint indexed offerId, address indexed buyer, uint escrowId, uint rating, uint date);
-   
+
 
     /**
      * @notice Create a new escrow
@@ -193,7 +193,7 @@ contract Escrow is Pausable, MessageSigned, Fees, Arbitrable {
             arbitrator: metadataStore.getArbitrator(_offerId)
         });
         transactionsByOfferId[_offerId].push(escrowId);
-        emit Created(_offerId, msg.sender, _buyer, escrowId, block.timestamp);
+        emit Created(_offerId, seller, _buyer, escrowId, block.timestamp);
         return escrowId;
     }
 
@@ -426,7 +426,7 @@ contract Escrow is Pausable, MessageSigned, Fees, Arbitrable {
         EscrowTransaction storage trx = transactions[_escrowId];
 
         require(trx.buyer != _arbitrator && metadataStore.getOfferOwner(trx.offerId) != _arbitrator, "Arbitrator cannot be part of transaction");
-        
+
         if(_releaseFunds){
             _release(_escrowId, trx);
         } else {

--- a/embarkConfig/contracts.js
+++ b/embarkConfig/contracts.js
@@ -244,7 +244,7 @@ module.exports = {
       protocol: 'https',
       type: "rpc"
     },
-    afterDeploy: dataMigration.bind(null, LICENSE_PRICE, FEE_AMOUNT),
+    afterDeploy: dataMigration.bind(null, LICENSE_PRICE, ARB_LICENSE_PRICE, FEE_AMOUNT),
     dappConnection: [
       "$WEB3"
     ]

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "i18next-browser-languagedetector": "^2.2.4",
     "identicon.js": "^2.3.3",
     "lodash": "^4.17.11",
+    "merge": "^1.2.1",
     "moment": "^2.23.0",
     "number-to-bn": "^1.7.0",
     "qrcode.react": "^0.9.3",

--- a/shared.chains.json
+++ b/shared.chains.json
@@ -40,6 +40,18 @@
       "0x44b05182627fb704aa6f702eaf846f686981d3e143fe6aae1a8fa830282d9925": {
         "name": "Escrow",
         "address": "0xF8E1fb93a7c32A0f28bb50aD6352c25385D139A7"
+      },
+      "0x99dd2a44cd0cd62354f6e3c27c706a4fdc8df7af396f831216b3c3f241b62759": {
+        "name": "Arbitration",
+        "address": "0x123762d3be5dfA76B360D84FC582B897Cf73A823"
+      },
+      "0x72b23054d301af648f043fe14dcd48d1bab737247301441f7ca7412d84221ef4": {
+        "name": "MetadataStore",
+        "address": "0xD7636B1B683cE37C68eF2e2749993a153f8E9374"
+      },
+      "0x2204177e69a37ad4a5aada676ea0e3a943f739242fb43dc132413711d38bea16": {
+        "name": "Escrow",
+        "address": "0x6C2b3367fD76EcD2363f4f818F15E7655c195854"
       }
     }
   }

--- a/shared.chains.json
+++ b/shared.chains.json
@@ -52,6 +52,10 @@
       "0x2204177e69a37ad4a5aada676ea0e3a943f739242fb43dc132413711d38bea16": {
         "name": "Escrow",
         "address": "0x6C2b3367fD76EcD2363f4f818F15E7655c195854"
+      },
+      "0xacd7275dcc7397adf479da0aa10e7adc0cbea8eb4f0d7f1fa6fc8af0c40d8eaf": {
+        "name": "Escrow",
+        "address": "0x257662a1866615f5c0E4A9D7633a3e317218e71A"
       }
     }
   }

--- a/src/js/components/Loading/index.jsx
+++ b/src/js/components/Loading/index.jsx
@@ -15,7 +15,7 @@ const Loading = ({t, mining, initial, page, value, txHash}) => (
       {page && t('loading.page')}
     </h3>
     <FontAwesomeIcon icon={faCircleNotch} size="5x" spin/>
-    {txHash && <p className="text-muted mb-0 mt-3">Transaction Hash: {txHash}</p>}
+    {txHash && <p className="text-muted mb-0 mt-3 text-break">Transaction Hash: {txHash}</p>}
   </div>
 );
 

--- a/src/js/components/Loading/index.jsx
+++ b/src/js/components/Loading/index.jsx
@@ -6,7 +6,7 @@ import {withNamespaces} from "react-i18next";
 
 import "./index.scss";
 
-const Loading = ({t, mining, initial, page, value}) => (
+const Loading = ({t, mining, initial, page, value, txHash}) => (
   <div className="loading" style={{"textAlign": "center"}}>
     <h3 className="mb-4">
       {value}
@@ -15,6 +15,7 @@ const Loading = ({t, mining, initial, page, value}) => (
       {page && t('loading.page')}
     </h3>
     <FontAwesomeIcon icon={faCircleNotch} size="5x" spin/>
+    {txHash && <p className="text-muted mb-0 mt-3">Transaction Hash: {txHash}</p>}
   </div>
 );
 
@@ -23,7 +24,8 @@ Loading.propTypes = {
   mining: PropTypes.bool,
   initial: PropTypes.bool,
   page: PropTypes.bool,
-  value: PropTypes.string
+  value: PropTypes.string,
+  txHash: PropTypes.string
 };
 
 export default withNamespaces()(Loading);

--- a/src/js/components/Loading/index.jsx
+++ b/src/js/components/Loading/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faCircleNotch} from "@fortawesome/free-solid-svg-icons";
 import {withNamespaces} from "react-i18next";
+import TxHash from '../../ui/TxHash';
 
 import "./index.scss";
 
@@ -15,7 +16,7 @@ const Loading = ({t, mining, initial, page, value, txHash}) => (
       {page && t('loading.page')}
     </h3>
     <FontAwesomeIcon icon={faCircleNotch} size="5x" spin/>
-    {txHash && <p className="text-muted mb-0 mt-3 text-break">Transaction Hash: {txHash}</p>}
+    {txHash && <p className="text-muted mb-0 mt-3 text-break">{t('transaction.hash')}: <TxHash value={txHash}/></p>}
   </div>
 );
 

--- a/src/js/features/escrow/actions.js
+++ b/src/js/features/escrow/actions.js
@@ -40,7 +40,7 @@ export const fundEscrow = (escrow) => {
       toSend,
       value,
       escrowId: escrow.escrowId
-    }
+    };
   }
 
   return {

--- a/src/js/features/escrow/actions.js
+++ b/src/js/features/escrow/actions.js
@@ -38,13 +38,15 @@ export const fundEscrow = (escrow) => {
     return {
       type: FUND_ESCROW,
       toSend,
-      value
-    };
+      value,
+      escrowId: escrow.escrowId
+    }
   }
 
   return {
     type: FUND_ESCROW,
-    toSend
+    toSend,
+    escrowId: escrow.escrowId
   };
 
   /*

--- a/src/js/features/escrow/reducer.js
+++ b/src/js/features/escrow/reducer.js
@@ -13,6 +13,7 @@ import {
 import { States } from '../../utils/transaction';
 import { escrowStatus } from './helpers';
 import {RESET_STATE} from "../network/constants";
+import merge from 'merge';
 
 const DEFAULT_STATE = {
   createEscrowStatus: States.none,
@@ -21,7 +22,6 @@ const DEFAULT_STATE = {
   payStatus: States.none,
   cancelStatus: States.none,
   rateStatus: States.none,
-  escrows: {},
   fee: '0'
 };
 
@@ -61,15 +61,14 @@ function reducer(state = DEFAULT_STATE, action) {
     case RATE_TRANSACTION_PRE_SUCCESS:
     case RELEASE_ESCROW_PRE_SUCCESS:
     case FUND_ESCROW_PRE_SUCCESS: {
-      const newEscrows = [...state.escrows];
-      newEscrows[escrowId] = {
+      escrowsClone[escrowId] = {
         ...state.escrows[escrowId],
         mining: true,
         txHash: action.txHash
       };
       return {
         ...state,
-        escrows: newEscrows
+        escrows: escrowsClone
       };
     }
     case RELEASE_ESCROW:
@@ -147,7 +146,7 @@ function reducer(state = DEFAULT_STATE, action) {
       }
       return {
         ...state,
-        escrows: Object.assign({}, state.escrows, action.escrows)
+        escrows: merge.recursive(state.escrows, action.escrows)
       };
     case GET_FEE_SUCCEEDED:
       return {

--- a/src/js/features/escrow/reducer.js
+++ b/src/js/features/escrow/reducer.js
@@ -31,7 +31,7 @@ function reducer(state = DEFAULT_STATE, action) {
   let escrowsClone = {...state.escrows};
   if (action.escrowId) {
     escrowsClone[action.escrowId] = {
-      ...state.escrows[action.escrowId],
+      ...escrowsClone[action.escrowId],
       mining: false,
       txHash: ''
     };
@@ -132,7 +132,11 @@ function reducer(state = DEFAULT_STATE, action) {
         txHash: ''
       };
     case GET_ESCROW_SUCCEEDED:
-      escrowsClone[escrowId] = action.escrow;
+      if (state.escrows[escrowId]) {
+        escrowsClone[escrowId] = merge.recursive(action.escrow, state.escrows[escrowId]);
+      } else {
+        escrowsClone[escrowId] = action.escrow;
+      }
       return {
         ...state,
         escrows: escrowsClone

--- a/src/js/features/escrow/saga.js
+++ b/src/js/features/escrow/saga.js
@@ -160,7 +160,7 @@ export function *doGetEscrow({escrowId}) {
     escrow.seller = yield MetadataStore.methods.users(sellerId).call();
     const buyerId = yield MetadataStore.methods.addressToUser(escrow.buyer).call();
     escrow.buyerInfo = yield MetadataStore.methods.users(buyerId).call();
-    yield put({type: GET_ESCROW_SUCCEEDED, escrow});
+    yield put({type: GET_ESCROW_SUCCEEDED, escrow, escrowId});
   } catch (error) {
     console.error(error);
     yield put({type: GET_ESCROW_FAILED, error: error.message});

--- a/src/js/features/escrow/selectors.js
+++ b/src/js/features/escrow/selectors.js
@@ -47,6 +47,9 @@ export const getTrades = (state, userAddress, offers) => {
 };
 
 export const getEscrowById = (state, escrowId) => {
+  if (!state.escrow.escrows) {
+    return null;
+  }
   const escrow = state.escrow.escrows[escrowId];
   if(!escrow) return null;
 

--- a/src/js/features/escrow/selectors.js
+++ b/src/js/features/escrow/selectors.js
@@ -19,8 +19,8 @@ export const getCreateEscrowId = state => state.escrow.createEscrowId;
 export const getRatingStatus = state => state.escrow.rateStatus;
 
 export const getTrades = (state, userAddress, offers) => {
-  const escrows = state.escrow.escrows || [];
-  return escrows.filter(escrow => escrow.buyer === userAddress || offers.find(x => x.toString() === escrow.offerId.toString()) !== undefined)
+  const escrows = state.escrow.escrows || {};
+  return Object.values(escrows).filter(escrow => escrow.buyer === userAddress || offers.find(x => x.toString() === escrow.offerId.toString()) !== undefined)
                 .map((escrow) => {
                   const token = Object.values(state.network.tokens).find((token) => web3.utils.toChecksumAddress(token.address) === web3.utils.toChecksumAddress(escrow.offer.asset));
                   return {
@@ -33,7 +33,7 @@ export const getTrades = (state, userAddress, offers) => {
 };
 
 export const getEscrowById = (state, escrowId) => {
-  const escrow = state.escrow.escrows.find(escrow => escrow.escrowId === escrowId);
+  const escrow = state.escrow.escrows[escrowId];
   if(!escrow) return null;
 
   const token = Object.values(state.network.tokens).find((token) => web3.utils.toChecksumAddress(token.address) === web3.utils.toChecksumAddress(escrow.offer.asset));
@@ -46,14 +46,14 @@ export const getEscrowById = (state, escrowId) => {
 };
 
 export const getFee = state => state.escrow.fee;
+export const txHash = state => state.escrow.txHash;
 
 // TODO: move to new UI
 export const receipt = state => state.escrow.receipt;
 export const error = state => state.escrow.error;
 export const isLoading = state => state.escrow.loading;
-export const txHash = state => state.escrow.txHash;
 export const txHashList = state => state.escrow.txHashList;
-export const escrows = state => state.escrow.escrows.map(escrow => {
+export const escrows = state => Object.values(state.escrow.escrows).map(escrow => {
   escrow.rating = (typeof escrow.rating === 'string') ? parseInt(escrow.rating, 10) : escrow.rating;
   if (!escrow.expirationTime.unix) {
     escrow.expirationTime = moment(escrow.expirationTime * 1000);

--- a/src/js/features/escrow/selectors.js
+++ b/src/js/features/escrow/selectors.js
@@ -2,7 +2,9 @@
 
 import moment from 'moment';
 import { fromTokenDecimals } from '../../utils/numbers';
-import { getTradeStatus } from './helpers';
+import { getTradeStatus, tradeStates } from './helpers';
+
+const unimportantStates = [tradeStates.canceled, tradeStates.expired, tradeStates.released];
 
 export const getCreateEscrowStatus = state => state.escrow.createEscrowStatus;
 
@@ -29,7 +31,19 @@ export const getTrades = (state, userAddress, offers) => {
                     status: getTradeStatus(escrow),
                     tokenAmount: fromTokenDecimals(escrow.tradeAmount, token.decimals)
                   };
-                });
+                })
+    .sort((a, b) => {
+      if (unimportantStates.includes(a.status)) {
+        if (unimportantStates.includes(b.status)) {
+          return (parseInt(a.escrowId, 10) < parseInt(b.escrowId, 10)) ? 1 : -1;
+        }
+        return 1;
+      }
+      if (unimportantStates.includes(b.status)) {
+        return -1;
+      }
+      return (parseInt(a.escrowId, 10) < parseInt(b.escrowId, 10)) ? 1 : -1;
+    });
 };
 
 export const getEscrowById = (state, escrowId) => {

--- a/src/js/features/escrow/selectors.js
+++ b/src/js/features/escrow/selectors.js
@@ -32,8 +32,8 @@ export const getTrades = (state, userAddress, offers) => {
                 });
 };
 
-export const getEscrow = (state) => {
-  const escrow = state.escrow.escrow;
+export const getEscrowById = (state, escrowId) => {
+  const escrow = state.escrow.escrows.find(escrow => escrow.escrowId === escrowId);
   if(!escrow) return null;
 
   const token = Object.values(state.network.tokens).find((token) => web3.utils.toChecksumAddress(token.address) === web3.utils.toChecksumAddress(escrow.offer.asset));

--- a/src/js/features/network/selectors.js
+++ b/src/js/features/network/selectors.js
@@ -16,3 +16,4 @@ export const getTokenByAddress = (state, address) => {
 };
 export const getStatusContactCode = (state) => state.network.contactCode;
 export const getENSError = state => state.network.ensError;
+export const getNetwork = state => state.network.network;

--- a/src/js/pages/Escrow/components/CardEscrowBuyer.jsx
+++ b/src/js/pages/Escrow/components/CardEscrowBuyer.jsx
@@ -2,11 +2,11 @@
 import React, {Component, Fragment} from 'react';
 import PropTypes from 'prop-types';
 import { Card, CardBody, Button } from 'reactstrap';
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faCircleNotch, faCheck, faTimes} from "@fortawesome/free-solid-svg-icons";
+import {faCheck, faTimes} from "@fortawesome/free-solid-svg-icons";
 
 import Reputation from '../../../components/Reputation';
 import RoundedIcon from "../../../ui/RoundedIcon";
+import Mining from "./Mining";
 
 import { States } from '../../../utils/transaction';
 import escrow from '../../../features/escrow';
@@ -15,7 +15,6 @@ import ConfirmDialog from '../../../components/ConfirmDialog';
 
 import one from "../../../../images/escrow/01.png";
 import two from "../../../../images/escrow/02.png";
-import three from "../../../../images/escrow/03.png";
 import four from "../../../../images/escrow/04.png";
 
 import Dispute from "./Dispute";
@@ -50,17 +49,6 @@ const Unreleased = () => (
     <p className="h2 mt-4">Waiting for the seller to release the funds</p>
     <p>Notify the seller about the trade using Status encrypted p2p chat</p>
     <Button color="primary" className="btn-lg mt-3" onClick={() => {}}>Open chat</Button>
-  </Fragment>
-);
-
-
-const Loading = () => (
-  <Fragment>
-    <span className="bg-dark text-white p-3 rounded-circle">
-      <img src={three} alt="three" />
-    </span>
-    <h2 className="mt-4">Waiting for the confirmations from the miners</h2>
-    <FontAwesomeIcon icon={faCircleNotch} size="5x" spin/>
   </Fragment>
 );
 
@@ -136,7 +124,7 @@ class CardEscrowBuyer extends Component {
         {!showLoading && ((showWaiting && trade.status !== escrow.helpers.tradeStates.released) || trade.status === escrow.helpers.tradeStates.paid) && <Unreleased /> }
         {!showLoading && trade.status === escrow.helpers.tradeStates.released && <Done trade={trade} rateTransaction={rateTransaction} /> }
         {!showLoading && trade.status === escrow.helpers.tradeStates.canceled && <Canceled/> }
-        {showLoading && <Loading /> }
+        {showLoading && <Mining txHash={trade.txHash} /> }
       </CardBody>
     </Card>;
   }

--- a/src/js/pages/Escrow/components/CardEscrowSeller.jsx
+++ b/src/js/pages/Escrow/components/CardEscrowSeller.jsx
@@ -68,8 +68,8 @@ class PreFund extends Component {
       return <Loading page={true}/>; // Wait for trade to be populated
     }
 
-    const enoughBalance = toBN(trade.token.balance ? toTokenDecimals(trade.token.balance, trade.token.decimals) : 0).gte(toBN(trade.tradeAmount)) &&
-                          toBN(toTokenDecimals(tokens.SNT.balance, 18)).gte(toBN(fee));
+    const enoughBalance = toBN(trade.token.balance ? toTokenDecimals(trade.token.balance || 0, trade.token.decimals) : 0).gte(toBN(trade.tradeAmount)) &&
+                          toBN(toTokenDecimals(tokens.SNT.balance || 0, 18)).gte(toBN(fee));
     return <Fragment>
       <span className="bg-dark text-white p-3 rounded-circle">
         <img src={two} alt="two" />
@@ -179,9 +179,9 @@ class CardEscrowSeller extends Component {
 
 
     if(showFundButton) step = 2;
-    if(fundStatus === States.pending) step = 3;
+    if(fundStatus === States.pending || (trade.mining && trade.status === escrow.helpers.tradeStates.waiting)) step = 3;
     if(fundStatus === States.success) step = 4;
-    if(releaseStatus === States.pending) step = 5;
+    if(releaseStatus === States.pending || (trade.mining && (trade.status === escrow.helpers.tradeStates.funded || trade.status === escrow.helpers.tradeStates.paid))) step = 5;
     if(releaseStatus === States.success || trade.status === escrow.helpers.tradeStates.released) step = 6;
 
     let component;
@@ -196,7 +196,7 @@ class CardEscrowSeller extends Component {
         component = <Funded trade={trade} releaseEscrow={() => { releaseEscrow(trade.escrowId); }} />;
         break;
       case 3:
-        component = <Mining txHash={trade.txHash} number={5} />;
+        component = <Mining txHash={trade.txHash} number={3} />;
         break;
       case 2:
         component = <PreFund tokens={tokens} showFundButton={showFundButton} fundEscrow={fundEscrow} trade={trade} fee={fee} showApproveScreen={showApproveScreen} />;

--- a/src/js/pages/Escrow/components/CardEscrowSeller.jsx
+++ b/src/js/pages/Escrow/components/CardEscrowSeller.jsx
@@ -2,11 +2,11 @@
 import React, {Component, Fragment} from 'react';
 import PropTypes from 'prop-types';
 import { Card, CardBody, Button } from 'reactstrap';
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faCircleNotch, faCheck} from "@fortawesome/free-solid-svg-icons";
+import {faCheck} from "@fortawesome/free-solid-svg-icons";
 import { fromTokenDecimals, toTokenDecimals } from '../../../utils/numbers';
 
 import RoundedIcon from "../../../ui/RoundedIcon";
+import Mining from "./Mining";
 
 import escrow from '../../../features/escrow';
 import { States } from '../../../utils/transaction';
@@ -14,7 +14,6 @@ import ConfirmDialog from '../../../components/ConfirmDialog';
 
 import one from "../../../../images/escrow/01.png";
 import two from "../../../../images/escrow/02.png";
-import three from "../../../../images/escrow/03.png";
 import four from "../../../../images/escrow/04.png";
 import Loading from "../../../components/Loading";
 
@@ -59,17 +58,6 @@ Funded.propTypes = {
   releaseEscrow: PropTypes.func,
   trade: PropTypes.object
 };
-
-const Funding = () => (
-  <Fragment>
-    <span className="bg-dark text-white p-3 rounded-circle">
-      <img src={three} alt="three" />
-    </span>
-    <h2 className="mt-4">Waiting for the confirmations from the miners</h2>
-    <FontAwesomeIcon icon={faCircleNotch} size="5x" spin/>
-  </Fragment>
-);
-
 
 class PreFund extends Component {
   render(){
@@ -191,20 +179,24 @@ class CardEscrowSeller extends Component {
 
 
     if(showFundButton) step = 2;
-    if(fundStatus === States.pending || releaseStatus === States.pending) step = 3;
+    if(fundStatus === States.pending) step = 3;
     if(fundStatus === States.success) step = 4;
-    if(releaseStatus === States.success || trade.status === escrow.helpers.tradeStates.released) step = 5;
+    if(releaseStatus === States.pending) step = 5;
+    if(releaseStatus === States.success || trade.status === escrow.helpers.tradeStates.released) step = 6;
 
     let component;
     switch(step){
-      case 5:
+      case 6:
         component = <Done />;
+        break;
+      case 5:
+        component = <Mining txHash={trade.txHash} number={5}  />;
         break;
       case 4:
         component = <Funded trade={trade} releaseEscrow={() => { releaseEscrow(trade.escrowId); }} />;
         break;
       case 3:
-        component = <Funding />;
+        component = <Mining txHash={trade.txHash} number={5} />;
         break;
       case 2:
         component = <PreFund tokens={tokens} showFundButton={showFundButton} fundEscrow={fundEscrow} trade={trade} fee={fee} showApproveScreen={showApproveScreen} />;

--- a/src/js/pages/Escrow/components/Mining.jsx
+++ b/src/js/pages/Escrow/components/Mining.jsx
@@ -2,14 +2,16 @@ import React from "react";
 import PropTypes from 'prop-types';
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faCircleNotch} from "@fortawesome/free-solid-svg-icons";
+import {withNamespaces} from "react-i18next";
 
 import one from "../../../../images/escrow/01.png";
 import two from "../../../../images/escrow/02.png";
 import three from "../../../../images/escrow/03.png";
 import four from "../../../../images/escrow/04.png";
 import five from "../../../../images/escrow/05.png";
+import TxHash from "../../../ui/TxHash";
 
-const Mining = ({txHash, number}) => {
+const Mining = ({txHash, number, t}) => {
   let image;
   switch(number) {
     case 1: image = one; break;
@@ -26,12 +28,14 @@ const Mining = ({txHash, number}) => {
     </span>
       <h2 className="mt-4">Waiting for the confirmations from the miners</h2>
       <FontAwesomeIcon icon={faCircleNotch} size="5x" spin/>
-      {txHash && <p className="text-muted mb-0 mt-3 text-break">Transaction Hash: {txHash}</p>}
+      {txHash && <p className="text-muted mb-0 mt-3 text-break">{t('transaction.hash')}: <TxHash value={txHash}/></p>}
     </div>);
 };
+
 Mining.propTypes = {
   txHash: PropTypes.string,
-  number: PropTypes.number
+  number: PropTypes.number,
+  t: PropTypes.func
 };
 
-export default Mining;
+export default withNamespaces()(Mining);

--- a/src/js/pages/Escrow/components/Mining.jsx
+++ b/src/js/pages/Escrow/components/Mining.jsx
@@ -1,4 +1,4 @@
-import React, {Fragment} from "react";
+import React from "react";
 import PropTypes from 'prop-types';
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faCircleNotch} from "@fortawesome/free-solid-svg-icons";
@@ -20,14 +20,14 @@ const Mining = ({txHash, number}) => {
     default: image = three;
   }
 
-  return (<Fragment>
+  return (<div className="text-center p-3">
     <span className="bg-dark text-white p-3 rounded-circle">
       <img src={image} alt="three"/>
     </span>
       <h2 className="mt-4">Waiting for the confirmations from the miners</h2>
       <FontAwesomeIcon icon={faCircleNotch} size="5x" spin/>
-      {txHash && <p className="text-muted mb-0 mt-3">Transaction Hash: {txHash}</p>}
-    </Fragment>);
+      {txHash && <p className="text-muted mb-0 mt-3 text-break">Transaction Hash: {txHash}</p>}
+    </div>);
 };
 Mining.propTypes = {
   txHash: PropTypes.string,

--- a/src/js/pages/Escrow/components/Mining.jsx
+++ b/src/js/pages/Escrow/components/Mining.jsx
@@ -1,0 +1,37 @@
+import React, {Fragment} from "react";
+import PropTypes from 'prop-types';
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faCircleNotch} from "@fortawesome/free-solid-svg-icons";
+
+import one from "../../../../images/escrow/01.png";
+import two from "../../../../images/escrow/02.png";
+import three from "../../../../images/escrow/03.png";
+import four from "../../../../images/escrow/04.png";
+import five from "../../../../images/escrow/05.png";
+
+const Mining = ({txHash, number}) => {
+  let image;
+  switch(number) {
+    case 1: image = one; break;
+    case 2: image = two; break;
+    case 3: image = three; break;
+    case 4: image = four; break;
+    case 5: image = five; break;
+    default: image = three;
+  }
+
+  return (<Fragment>
+    <span className="bg-dark text-white p-3 rounded-circle">
+      <img src={image} alt="three"/>
+    </span>
+      <h2 className="mt-4">Waiting for the confirmations from the miners</h2>
+      <FontAwesomeIcon icon={faCircleNotch} size="5x" spin/>
+      {txHash && <p className="text-muted mb-0 mt-3">Transaction Hash: {txHash}</p>}
+    </Fragment>);
+};
+Mining.propTypes = {
+  txHash: PropTypes.string,
+  number: PropTypes.number
+};
+
+export default Mining;

--- a/src/js/pages/Escrow/index.jsx
+++ b/src/js/pages/Escrow/index.jsx
@@ -91,7 +91,7 @@ class Escrow extends Component {
     let {escrow, arbitration, fee, address, sntAllowance, tokenAllowance, loading, tokens, fundEscrow, fundStatus, cancelEscrow, releaseEscrow, releaseStatus, payStatus, payEscrow, rateTransaction, approvalTxHash} = this.props;
     const {showApproveFundsScreen} = this.state;
 
-    if(!escrow || !sntAllowance) return <Loading page={true} />;
+    if(!escrow || (!sntAllowance && sntAllowance !== 0)) return <Loading page={true} />;
     if(loading) return <Loading mining={true} txHash={escrow.txHash || approvalTxHash}/>;
 
     const arbitrationDetails = arbitration.arbitration;

--- a/src/js/pages/Escrow/index.jsx
+++ b/src/js/pages/Escrow/index.jsx
@@ -88,11 +88,11 @@ class Escrow extends Component {
   }
 
   render() {
-    let {escrow, arbitration, fee, address, sntAllowance, tokenAllowance, loading, tokens, fundEscrow, fundStatus, cancelEscrow, releaseEscrow, releaseStatus, payStatus, payEscrow, rateTransaction} = this.props;
+    let {escrow, arbitration, fee, address, sntAllowance, tokenAllowance, loading, tokens, fundEscrow, fundStatus, cancelEscrow, releaseEscrow, releaseStatus, payStatus, payEscrow, rateTransaction, approvalTxHash} = this.props;
     const {showApproveFundsScreen} = this.state;
 
     if(!escrow || !sntAllowance) return <Loading page={true} />;
-    if(loading) return <Loading mining={true} />;
+    if(loading) return <Loading mining={true} txHash={escrow.txHash || approvalTxHash}/>;
 
     const arbitrationDetails = arbitration.arbitration;
 
@@ -181,6 +181,7 @@ Escrow.propTypes = {
   payStatus: PropTypes.string,
   payEscrow: PropTypes.func,
   cancelStatus: PropTypes.string,
+  approvalTxHash: PropTypes.string,
   cancelEscrow: PropTypes.func,
   updateBalances: PropTypes.func,
   rateTransaction: PropTypes.func,
@@ -191,15 +192,17 @@ const mapStateToProps = (state, props) => {
   const cancelStatus = escrow.selectors.getCancelEscrowStatus(state);
   const approvalLoading = approval.selectors.isLoading(state);
   const ratingStatus = escrow.selectors.getRatingStatus(state);
+  const escrowId = props.match.params.id.toString();
 
   return {
     address: network.selectors.getAddress(state) || "",
-    escrowId:  props.match.params.id.toString(),
-    escrow: escrow.selectors.getEscrow(state),
+    escrowId:  escrowId,
+    escrow: escrow.selectors.getEscrowById(state, escrowId),
     arbitration: arbitration.selectors.getArbitration(state) || {},
     fee: escrow.selectors.getFee(state),
     sntAllowance: approval.selectors.getSNTAllowance(state),
     tokenAllowance: approval.selectors.getTokenAllowance(state),
+    approvalTxHash: approval.selectors.txHash(state),
     tokens: network.selectors.getTokens(state),
     loading: cancelStatus === States.pending || ratingStatus === States.pending || approvalLoading,
     fundStatus: escrow.selectors.getFundEscrowStatus(state),

--- a/src/js/pages/MyProfile/components/Trades.jsx
+++ b/src/js/pages/MyProfile/components/Trades.jsx
@@ -10,6 +10,9 @@ import {formatBalance} from "../../../utils/numbers";
 import {tradeStates} from "../../../features/escrow/helpers";
 
 const getTradeStyle = (trade) => {
+  if (trade.mining) {
+    return {text: 'Mining', className: 'bg-info'};
+  }
   if(trade.arbitration){
     if(trade.arbitration.open){
       trade.status = tradeStates.arbitration_open;
@@ -22,11 +25,13 @@ const getTradeStyle = (trade) => {
 
   switch(trade.status){
     case tradeStates.waiting:
+      return {text: 'Open', className: 'bg-primary'};
     case tradeStates.funded:
+      return {text: 'Funded', className: 'bg-primary'};
     case tradeStates.paid:
-      return {text: 'Open', className: 'bg-success'};
+      return {text: 'Paid', className: 'bg-primary'};
     case tradeStates.released:
-      return {text: 'Closed', className: 'bg-primary'};
+      return {text: 'Done', className: 'bg-success'};
     case tradeStates.canceled:
       return {text: 'Canceled', className: 'bg-secondary'};
     case tradeStates.expired:

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -22,7 +22,7 @@ const persistConfig = {
   key: 'teller-network-store',
   storage,
   stateReconciler: autoMergeLevel2,
-  blacklist: ['network', 'escrow', 'approval', 'router']
+  blacklist: ['network', 'approval', 'router']
 };
 
 function *root() {

--- a/src/js/ui/TxHash/index.js
+++ b/src/js/ui/TxHash/index.js
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from 'prop-types';
+import network from "../../features/network";
+import {connect} from "react-redux";
+
+const etherScanUrls = {
+  1: 'https://etherscan.io/tx/',
+  3: 'https://ropsten.etherscan.io/tx/',
+  4: 'https://rinkeby.etherscan.io/tx/',
+  5: 'https://goerli.etherscan.io/tx/',
+  42: 'https://kovan.etherscan.io/tx/',
+  401697: 'https://tobalaba.etherscan.com/tx/'
+};
+
+const TxHash = ({value, network}) => {
+  if (!network || (!network.id && network.id !== 0) || !etherScanUrls[network.id]) {
+    return value;
+  }
+
+  return (<a href={etherScanUrls[network.id] + value} target="_blank" rel="noopener noreferrer">{value}</a>);
+};
+
+TxHash.propTypes = {
+  value: PropTypes.string,
+  network: PropTypes.object
+};
+
+const mapStateToProps = state => ({
+  network: network.selectors.getNetwork(state)
+});
+
+export default connect(
+  mapStateToProps
+)(TxHash);

--- a/src/js/ui/TxHash/index.js
+++ b/src/js/ui/TxHash/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from 'prop-types';
-import network from "../../features/network";
+import {getNetwork} from "../../features/network/selectors";
 import {connect} from "react-redux";
 
 const etherScanUrls = {
@@ -26,7 +26,7 @@ TxHash.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  network: network.selectors.getNetwork(state)
+  network: getNetwork(state)
 });
 
 export default connect(

--- a/src/js/utils/saga.js
+++ b/src/js/utils/saga.js
@@ -23,10 +23,13 @@ export function *doTransaction(preSuccess, success, failed, {value = 0, toSend})
     const estimatedGas = yield call(toSend.estimateGas, {value});
     const promiseEvent = toSend.send({gasLimit: estimatedGas + 1000, from: web3.eth.defaultAccount, value});
     const channel = eventChannel(promiseEventEmitter.bind(null, promiseEvent));
+    const parsedPayload = cloneDeep(arguments[3]);
+    delete parsedPayload.toSend;
+    delete parsedPayload.type;
     while (true) {
       const {hash, receipt, error} = yield take(channel);
       if (hash) {
-        yield put({type: preSuccess, txHash: hash});
+        yield put({type: preSuccess, txHash: hash, ...parsedPayload});
       } else if (receipt) {
         const parsedPayload = cloneDeep(arguments[3]);
         delete parsedPayload.toSend;

--- a/src/js/wizards/Buy/1_Trade/index.jsx
+++ b/src/js/wizards/Buy/1_Trade/index.jsx
@@ -100,7 +100,7 @@ class Trade extends Component {
 
     switch(this.props.createEscrowStatus){
       case States.pending:
-        return <Loading mining/>;
+        return <Loading mining txHash={this.props.txHash}/>;
       case States.failed:
         return <ErrorInformation transaction retry={this.postEscrow} cancel={this.props.resetStatus}/>;
       case States.none:
@@ -135,6 +135,7 @@ Trade.propTypes = {
   assetQuantity: PropTypes.number,
   footer: PropTypes.object,
   statusContactCode: PropTypes.string,
+  txHash: PropTypes.string,
   username: PropTypes.string,
   loadOffers: PropTypes.func,
   offerId: PropTypes.number,
@@ -153,6 +154,7 @@ const mapStateToProps = (state) => {
   return {
     createEscrowStatus: escrow.selectors.getCreateEscrowStatus(state),
     escrowId: escrow.selectors.getCreateEscrowId(state),
+    txHash: escrow.selectors.txHash(state),
     statusContactCode: newBuy.selectors.statusContactCode(state),
     username: newBuy.selectors.username(state),
     currencyQuantity: newBuy.selectors.currencyQuantity(state),

--- a/stories/components/loading.stories.jsx
+++ b/stories/components/loading.stories.jsx
@@ -13,6 +13,12 @@ storiesOf('Components/Loading', module)
     ))
   )
   .add(
+    "Mining + Hash",
+    withInfo({inline: true})(() => (
+      <Loading mining txHash="0xcc21e58519f0c048267b020911d3f6822ffd63a5b1ce7ea4c506fddfb78699ad" />
+    ))
+  )
+  .add(
     "Page",
     withInfo({inline: true})(() => (
       <Loading page />

--- a/stories/components/mining.stories.jsx
+++ b/stories/components/mining.stories.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import {storiesOf} from '@storybook/react';
+import {withInfo} from "@storybook/addon-info";
+
+import Mining from '../../src/js/pages/Escrow/components/Mining';
+
+storiesOf('Components/Mining', module)
+  .add(
+    "Mining",
+    withInfo({inline: true})(() => (
+      <Mining />
+    ))
+  )
+  .add(
+    "Mining + Hash",
+    withInfo({inline: true})(() => (
+      <Mining txHash="0xcc21e58519f0c048267b020911d3f6822ffd63a5b1ce7ea4c506fddfb78699ad" />
+    ))
+  );

--- a/stories/components/userInformation.stories.jsx
+++ b/stories/components/userInformation.stories.jsx
@@ -12,7 +12,7 @@ storiesOf('Components/UserInformation', module)
   .add(
     "Default",
     withInfo({inline: true})(() => (
-      <UserInformation identiconSeed={"0x123123123123123123123123123"} username={"Eric"} reputation={{upCount: 432, downCount: 54}}/>
+      <UserInformation identiconSeed={"0x04c3189dd7c10a6211432a254508aa7da0f4cb35ec8ac690d403427666793e36003c4b615053b633d387561a55bbe2e91d4d39911fa52a0f9933f659d059aa0f3e"} username={"Eric"} reputation={{upCount: 432, downCount: 54}}/>
     ))
   )
   .add(

--- a/yarn.lock
+++ b/yarn.lock
@@ -11569,7 +11569,7 @@ merge2@^1.2.3:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
   integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
 
-merge@1.2.1, merge@^1.2.0:
+merge@1.2.1, merge@^1.2.0, merge@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==


### PR DESCRIPTION
This is a pretty big one in the fact that it touches the whole state management of the escrows.

The goal: make the flow more reactive and more informative.

With this, when a Tx is sent, the user gets a link to etherscan with the tx hash. He can also go back to the profile and see the actual state of the TX and go back to it and when it's done, all the states are correctly updated.

Includes a couple of other fixes and improvement, but here is what the new states in the list look like:
![image](https://user-images.githubusercontent.com/11926403/57885494-0c64b780-77f9-11e9-9ba4-335e15433a49.png)
