### PR TITLE
Remove useless blockchain calls and use the state instead

### DIFF
--- a/src/js/features/arbitration/saga.js
+++ b/src/js/features/arbitration/saga.js
@@ -48,16 +48,10 @@ export function *doGetEscrows() {
       const escrowId = events[i].returnValues.escrowId;
 
       const escrow = yield call(Escrow.methods.transactions(escrowId).call);
-      const buyerId = yield MetadataStore.methods.addressToUser(escrow.buyer).call();
-      const buyer = yield MetadataStore.methods.users(buyerId).call();
       const offer = yield MetadataStore.methods.offers(escrow.offerId).call();
-      const sellerId = yield MetadataStore.methods.addressToUser(offer.owner).call();
-      const seller = yield MetadataStore.methods.users(sellerId).call();
 
       escrow.escrowId = escrowId;
       escrow.seller = offer.owner;
-      escrow.buyerInfo = buyer;
-      escrow.sellerInfo = seller;
       escrow.arbitration = yield call(Arbitration.methods.arbitrationCases(escrowId).call);
       escrow.arbitration.createDate = moment(events[i].returnValues.date * 1000).format("DD.MM.YY");
 
@@ -82,20 +76,13 @@ export function *onGetEscrows() {
 export function *doLoadArbitration({escrowId}) {
   try {
     const escrow = yield call(Escrow.methods.transactions(escrowId).call);
-    const buyerId = yield MetadataStore.methods.addressToUser(escrow.buyer).call();
-    const buyer = yield MetadataStore.methods.users(buyerId).call();
     const offer = yield MetadataStore.methods.offers(escrow.offerId).call();
-    const sellerId = yield MetadataStore.methods.addressToUser(offer.owner).call();
-    const seller = yield MetadataStore.methods.users(sellerId).call();
 
     const events = yield Escrow.getPastEvents('Created', {fromBlock: 1, filter: {escrowId: escrowId} });
 
-    // TODO: remove buyer info from here, we should get it from the state
     escrow.createDate = moment(events[0].returnValues.date * 1000).format("DD.MM.YY");
     escrow.escrowId = escrowId;
     escrow.seller = offer.owner;
-    escrow.buyerInfo = buyer;
-    escrow.sellerInfo = seller;
     escrow.offer = offer;
     escrow.arbitration = yield call(Arbitration.methods.arbitrationCases(escrowId).call);
 

--- a/src/js/pages/Arbitration/components/EscrowDetail.jsx
+++ b/src/js/pages/Arbitration/components/EscrowDetail.jsx
@@ -5,9 +5,9 @@ import PropTypes from 'prop-types';
 const EscrowDetail = ({escrow}) => <Row className="mt-4">
     <Col xs="10">
       <h5 className="m-0">Trade details</h5>
-      <p className="text-dark m-0">{(escrow.tokenAmount * escrow.assetPrice / 100).toFixed(2)} {escrow.offer.currency} for {escrow.tokenAmount} {escrow.token.symbol}</p>
-      <p className="text-dark m-0">{escrow.token.symbol} Price = {escrow.assetPrice / 100} {escrow.offer.currency}</p>
-      <p className="text-dark m-0">Took place on {escrow.createDate}</p>
+      <p className="m-0">{(escrow.tokenAmount * escrow.assetPrice / 100).toFixed(2)} {escrow.offer.currency} for {escrow.tokenAmount} {escrow.token.symbol}</p>
+      <p className="m-0">{escrow.token.symbol} Price = {escrow.assetPrice / 100} {escrow.offer.currency}</p>
+      <p className="m-0">Took place on {escrow.createDate}</p>
     </Col>
   </Row>;
 

--- a/src/js/pages/Arbitration/index.jsx
+++ b/src/js/pages/Arbitration/index.jsx
@@ -17,6 +17,7 @@ import metadata from '../../features/metadata';
 import CheckButton from '../../ui/CheckButton';
 import Identicon from "../../components/UserInformation/Identicon";
 import ConfirmDialog from "../../components/ConfirmDialog";
+import bubbleTriangle from "../../../images/diamond.png";
 
 import {addressCompare} from "../../utils/address";
 
@@ -111,14 +112,19 @@ class Arbitration extends Component {
       <div className="escrow">
         <h2>Dispute Details <span className={"arbitrationStatus " + status}>{status}</span></h2>
         <p className="arbitrationMotive mt-3 mb-0">{escrow.arbitration.motive}</p>
-        <span className="triangle" />{/* FIXME should be like a comic book bubble */}
-        <TradeParticipant address={escrow.arbitration.openBy} profile={escrow.arbitration.openBy === escrow.buyer ? buyerInfo : sellerInfo} />
-        <EscrowDetail escrow={escrow} />
+        <span className="triangle"><img src={bubbleTriangle} alt="buble-triangle"/></span>
+        <TradeParticipant address={escrow.arbitration.openBy}
+                          profile={escrow.arbitration.openBy === escrow.buyer ? buyerInfo : sellerInfo}/>
+
+        <EscrowDetail escrow={escrow}/>
+
         <h5 className="mt-4">Trade participants</h5>
-        <TradeParticipant address={escrow.buyer} profile={buyerInfo} />
-        <TradeParticipant address={escrow.seller} profile={sellerInfo} />
-        <ContactUser username={buyerInfo.username} seed={escrow.buyer} statusContactCode={buyerInfo.statusContactCode} />
-        <ContactUser username={sellerInfo.username} seed={escrow.seller} statusContactCode={sellerInfo.statusContactCode}  />
+        <TradeParticipant address={escrow.buyer} profile={buyerInfo}/>
+        <TradeParticipant address={escrow.seller} profile={sellerInfo}/>
+
+        <ContactUser username={buyerInfo.username} seed={escrow.buyer} statusContactCode={buyerInfo.statusContactCode}/>
+        <ContactUser username={sellerInfo.username} seed={escrow.seller} statusContactCode={sellerInfo.statusContactCode}/>
+
         {(escrow.arbitration.open || escrow.arbitration.result.toString() === "0") && (
           <Fragment>
             <Row className="mt-4">
@@ -128,6 +134,7 @@ class Arbitration extends Component {
               </Col>
               <Col xs={3} />
             </Row>
+
             <Modal isOpen={displayUsers} toggle={this.handleClose} backdrop={true} className="arbitrationDialog" >
               <ModalBody>
                 <h2 className="text-center">Your decision</h2>

--- a/src/js/pages/Arbitration/index.scss
+++ b/src/js/pages/Arbitration/index.scss
@@ -3,14 +3,12 @@
   background: #000;
   text-transform: uppercase;
   color: #fff;
-  font-family: Inter;
-  font-style: normal;
   font-weight: bold;
   font-size: 11px;
-  line-height: normal;
-  text-align: center;
   letter-spacing: 1px;
   padding: 3px 10px;
+  position: relative;
+  top: -3px;
 }
 
 .arbitrationDialog button svg {
@@ -38,9 +36,9 @@ h5 {
 }
 
 .triangle {
-  width: 20px;
-  height: 8px;
-  background: url(/images/diamond.png) no-repeat bottom center;
   display: block;
-  margin: 0 0 5px 20px;
+  position: relative;
+  top: -15px;
+  left: 18px;
+  margin-bottom: -8px;
 }

--- a/src/js/pages/MyProfile/components/Dispute.jsx
+++ b/src/js/pages/MyProfile/components/Dispute.jsx
@@ -1,0 +1,63 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {Card} from 'reactstrap';
+import Identicon from "../../../components/UserInformation/Identicon";
+import {Link} from "react-router-dom";
+import {connect} from "react-redux";
+import metadata from "../../../features/metadata";
+
+class Dispute extends Component {
+  constructor(props) {
+    super(props);
+    if (!props.sellerInfo) {
+      props.loadProfile(props.dispute.seller);
+    }
+    if (!props.buyerInfo) {
+      props.loadProfile(props.dispute.buyer);
+    }
+  }
+
+  render() {
+    const {dispute, buyerInfo, sellerInfo} = this.props;
+
+    if (!buyerInfo || !sellerInfo) {
+      return null;
+    }
+
+    return (<Card body className="py-2 px-3 mb-3 shadow-sm">
+        <div className="d-flex my-1">
+            <span className="flex-fill align-self-center">
+              <Link to={"/arbitration/" + dispute.escrowId}>
+                 <Identicon seed={buyerInfo.statusContactCode} scale={5} className="align-middle rounded-circle topCircle border"/>
+                 <Identicon seed={sellerInfo.statusContactCode} scale={5} className="align-middle rounded-circle bottomCircle border"/>
+                <span className="ml-2">{buyerInfo.username} & {sellerInfo.username}</span>
+              </Link>
+            </span>
+          <span className="flex-fill align-self-center text-right">
+              {this.props.showDate && dispute.arbitration.createDate}
+            </span>
+        </div>
+      </Card>);
+  }
+}
+
+Dispute.propTypes = {
+  dispute: PropTypes.object,
+  showDate: PropTypes.bool,
+  sellerInfo: PropTypes.object,
+  buyerInfo: PropTypes.object,
+  loadProfile: PropTypes.func
+};
+
+const mapStateToProps = (state, props) => {
+  return {
+    buyerInfo: metadata.selectors.getProfile(state, props.dispute.buyer),
+    sellerInfo: metadata.selectors.getProfile(state, props.dispute.seller)
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  {
+    loadProfile: metadata.actions.load
+  })(Dispute);

--- a/src/js/pages/MyProfile/components/Disputes.jsx
+++ b/src/js/pages/MyProfile/components/Disputes.jsx
@@ -2,27 +2,12 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {Card} from 'reactstrap';
 import {withNamespaces} from 'react-i18next';
-import Identicon from "../../../components/UserInformation/Identicon";
-import {Link} from "react-router-dom";
+import Dispute from './Dispute';
 
 class Disputes extends Component {
   renderTrades() {
     return (
-        this.props.disputes.map((dispute, index) => <Card key={index} body className="py-2 px-3 mb-3 shadow-sm">
-          <div className="d-flex my-1">
-            <span className="flex-fill align-self-center">
-              <Link to={"/arbitration/" + dispute.escrowId}>
-                 <Identicon seed={dispute.buyerInfo.statusContactCode} scale={5} className="align-middle rounded-circle topCircle border"/>
-                 <Identicon seed={dispute.sellerInfo.statusContactCode} scale={5} className="align-middle rounded-circle bottomCircle border"/>
-                <span className="ml-2">{dispute.buyerInfo.username} & {dispute.sellerInfo.username}</span>
-              </Link>
-            </span>
-            <span className="flex-fill align-self-center text-right">
-              {this.props.showDate && dispute.arbitration.createDate}
-            </span>
-          </div>
-          </Card>
-        )
+        this.props.disputes.map((dispute, index) => <Dispute key={'dispute-' + index} dispute={dispute} showDate={this.props.showDate}/>)
     );
   }
 

--- a/src/js/pages/MyProfile/index.jsx
+++ b/src/js/pages/MyProfile/index.jsx
@@ -87,7 +87,6 @@ const mapStateToProps = state => {
   };
 };
 
-
 export default connect(
   mapStateToProps,
   {


### PR DESCRIPTION
We fetched the buyer and seller info from the chain for arbitrations when it was useless. That's the responsibility of the metadata state, so I moved that logic in the Dispute component and we only load the profiles if they weren't already loaded.