### PR TITLE
Add a Back button on all pages except some

### DIFF
--- a/src/js/layout/App.jsx
+++ b/src/js/layout/App.jsx
@@ -24,6 +24,7 @@ import ArbitrationLicense from '../pages/ArbitrationLicense';
 import OffersList from '../pages/OffersList';
 import OffersMap from '../pages/OffersMap';
 import Settings from '../pages/Settings';
+import BackButton from '../ui/BackButton';
 
 // Buy
 import BuyContact from '../wizards/Buy/0_Contact';
@@ -95,6 +96,7 @@ class App extends Component {
         <Container className="p-0">
           <Header profile={this.props.profile}/>
           <div className="body-content">
+            <BackButton/>
           <Switch>
             <Route exact path="/" component={Home}/>
 

--- a/src/js/ui/BackButton/index.jsx
+++ b/src/js/ui/BackButton/index.jsx
@@ -1,0 +1,45 @@
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
+import {withRouter} from "react-router-dom";
+import {Button} from "reactstrap";
+import arrow from "../../../images/arrow.png";
+
+const BLACK_LIST = ['/', '/offers/list', '/sell/*'];
+
+class BackButton extends Component {
+  state = {
+    hidden: null
+  };
+
+  componentDidUpdate(prevProps) {
+    if (this.state.hidden === null || prevProps.location.pathname !== this.props.location.pathname) {
+      const hidden = !!BLACK_LIST.find(blackListedLink => {
+        const starIndex = blackListedLink.indexOf('*');
+        if (starIndex > -1) {
+          blackListedLink = blackListedLink.substring(0, starIndex);
+          return this.props.location.pathname.startsWith(blackListedLink);
+        }
+        return BLACK_LIST.includes(this.props.location.pathname);
+      });
+      this.setState({hidden});
+    }
+  }
+
+  render() {
+    if (this.state.hidden) {
+      return null;
+    }
+    return (<p className="back-button">
+      <Button color="link" className="p-0" onClick={this.props.history.goBack}>
+        <img className="fa-rotate-180 footer-arrow mr-2" src={arrow} alt="previous arrow"/> Back
+      </Button>
+    </p>);
+  }
+}
+
+BackButton.propTypes = {
+  history: PropTypes.object,
+  location: PropTypes.object
+};
+
+export default withRouter(BackButton);


### PR DESCRIPTION
Adds a back button (that takes you back), on all pages except the ones that have been blcklisted.
Current blacklist:
- home
- Offer list
- sell wizard

You can add pages in the component by just adding to the array and you can use a `*` to match all that starts with something, like I did with the sell path (`/sell/*`)

Need to check if the blacklist work on the gh-pages, because I'm not sure how the pathname works there.

![image](https://user-images.githubusercontent.com/11926403/58490020-64c18080-813a-11e9-82db-42ebdfc9c5c8.png)
