### PR TITLE
Show error on escrow even when switching page

### DIFF
--- a/shared.chains.json
+++ b/shared.chains.json
@@ -91,15 +91,15 @@
       },
       "0x640045a97c238d558f5618071e182a716f361a4d1ee587ef2dab65edb4b669d4": {
         "name": "Arbitration",
-        "address": "0x82eD56194FeC279f253CF8a44453f83e49d185B2"
+        "address": "0x9F71b26295a725ef6E0560f54792c0d26935c4DF"
       },
-      "0xa672c575071909495545b866c6b80b52cce03a1d4ecd7a9dc91db3cf379b5cd9": {
+      "0x2b299ea77e760d0b0a0ec341f867097b9bafdd56f675fe0e4b190467f3e96f15": {
         "name": "MetadataStore",
-        "address": "0xDA515DC823624ECA172E796C80E7b8746f275Bd0"
+        "address": "0x5b4D32279bb72e25bcFF67257D402f1eeE9053B2"
       },
-      "0xd933ce15095baad378aa350e9b2965fd97f31cad039f580f57cdd587fa004ccd": {
+      "0x2e8c05d27fd0d12701b3d09a6821f04f120602701f23e5c62210dfcc978e00a5": {
         "name": "Escrow",
-        "address": "0xfdf8F912b5d489bDa96dc5bFF3135cf702aC2f8F"
+        "address": "0x1c5BF079fc52c1E711b5aC73E189264Cb6593B92"
       }
     }
   }

--- a/src/js/pages/Escrow/index.jsx
+++ b/src/js/pages/Escrow/index.jsx
@@ -41,7 +41,6 @@ class Escrow extends Component {
     props.loadArbitration(props.escrowId);
     props.getFee();
     props.getSNTAllowance();
-    props.resetStatus();
     props.updateBalances();
 
     if (props.escrow) props.getTokenAllowance(props.escrow.offer.asset);
@@ -105,6 +104,10 @@ class Escrow extends Component {
       cancelEscrow, releaseEscrow, releaseStatus, payStatus, rateStatus, payEscrow, rateTransaction, approvalTxHash, 
       approvalError, cancelDispute} = this.props;
     const {showApproveFundsScreen} = this.state;
+
+    if (releaseStatus === States.failed || payStatus === States.failed || rateStatus === States.failed || fundStatus === States.failed) {
+      return <ErrorInformation transaction={true} cancel={this.props.resetStatus}/>;
+    }
 
     if(!escrow || (!sntAllowance && sntAllowance !== 0) || !arbitration || !arbitration.arbitration) {
       return <Loading page={true} />;


### PR DESCRIPTION
Before, we didn,t actually show any error on escrow tx errors. This was further accentuated by the fact that we reset the escrow states when loading the escrow page.
With this change, the error is displayed and also it is persisted when changing page.

Downside: if you start a TX for escrow 1, go to your profile while it's mining, it errors and then you go to escrow 2 (not the same escrow), you will see the error of escrow 1.

At least it shows the error, and the user should be smart enough to understand that it's related to the tx he did in the first escrow.

We should however refactor how we handle escrow states so that it is per escrow, instead of global escrow states.