### PR TITLE
Put status in escrow object to better handle states

### DIFF
--- a/src/js/features/escrow/actions.js
+++ b/src/js/features/escrow/actions.js
@@ -79,7 +79,7 @@ export const cancelEscrow = (escrowId) => ({ type: CANCEL_ESCROW, escrowId, toSe
 
 export const rateTransaction = (escrowId, rating) => ({ type: RATE_TRANSACTION, escrowId, rating, toSend: Escrow.methods.rateTransaction(escrowId, rating) });
 
-export const resetStatus = () => ({type: RESET_STATUS});
+export const resetStatus = (escrowId) => ({type: RESET_STATUS, escrowId});
 
 export const watchEscrow = (escrowId) => ({type: WATCH_ESCROW, escrowId});
 export const watchEscrowCreations = (offers) => ({type: WATCH_ESCROW_CREATIONS, offers});

--- a/src/js/features/escrow/reducer.js
+++ b/src/js/features/escrow/reducer.js
@@ -19,7 +19,6 @@ import merge from 'merge';
 const DEFAULT_STATE = {
   escrows: {},
   createEscrowStatus: States.none,
-  fundEscrowStatus: States.none,
   releaseStatus: States.none,
   payStatus: States.none,
   cancelStatus: States.none,
@@ -43,22 +42,23 @@ function reducer(state = DEFAULT_STATE, action) {
 
   switch (action.type) {
     case FUND_ESCROW:
+      escrowsClone[escrowId].fundStatus = States.pending;
       return {
         ...state,
-        fundEscrowStatus: States.pending
+        escrows: escrowsClone
       };
     case FUND_ESCROW_FAILED:
+      escrowsClone[escrowId].fundStatus = States.failed;
       return {
         ...state,
-        fundEscrowStatus: States.failed,
         escrows: escrowsClone
       };
     case FUND_ESCROW_SUCCEEDED:
+      escrowsClone[escrowId].fundStatus = States.success;
       escrowsClone[escrowId].expirationTime = action.expirationTime;
       escrowsClone[escrowId].status = escrowStatus.FUNDED;
       return {
         ...state,
-        fundEscrowStatus: States.success,
         escrows: escrowsClone
       };
     case PAY_ESCROW_PRE_SUCCESS:
@@ -248,13 +248,17 @@ function reducer(state = DEFAULT_STATE, action) {
         chnagedEscrow: null
       };
     case RESET_STATUS:
-      return {
-        ...state,
-        fundEscrowStatus: States.none,
+      escrowsClone[escrowId] = {
+        ...escrowsClone[escrowId],
+        fundStatus: States.none,
         createEscrowStatus: States.none,
         payStatus: States.none,
         releaseStatus: States.none,
         rateStatus: States.none
+      };
+      return {
+        ...state,
+        escrows: escrowsClone
       };
     case PURGE_STATE:
     case RESET_STATE: {

--- a/src/js/features/escrow/reducer.js
+++ b/src/js/features/escrow/reducer.js
@@ -19,7 +19,6 @@ import merge from 'merge';
 const DEFAULT_STATE = {
   escrows: {},
   createEscrowStatus: States.none,
-  cancelStatus: States.none,
   rateStatus: States.none,
   fee: '0',
   newEscrow: null,
@@ -164,23 +163,23 @@ function reducer(state = DEFAULT_STATE, action) {
         fee: action.fee
       };
     case CANCEL_ESCROW:
+      escrowsClone[escrowId].cancelStatus = States.pending;
       return {
         ...state,
-        cancelStatus: States.pending
+        escrows: escrowsClone
       };
-    case CANCEL_ESCROW_SUCCEEDED:
-      {
-        escrowsClone[escrowId].status = escrowStatus.CANCELED;
-        return {
-          ...state,
-          escrows: escrowsClone,
-          cancelStatus: States.success
-        };
-      }
-    case CANCEL_ESCROW_FAILED:
+    case CANCEL_ESCROW_SUCCEEDED: {
+      escrowsClone[escrowId].cancelStatus = States.success;
+      escrowsClone[escrowId].status = escrowStatus.CANCELED;
       return {
         ...state,
-        cancelStatus: States.failed,
+        escrows: escrowsClone
+      };
+    }
+    case CANCEL_ESCROW_FAILED:
+      escrowsClone[escrowId].cancelStatus = States.failed;
+      return {
+        ...state,
         escrows: escrowsClone
       };
     case RATE_TRANSACTION:
@@ -255,7 +254,8 @@ function reducer(state = DEFAULT_STATE, action) {
         createEscrowStatus: States.none,
         payStatus: States.none,
         releaseStatus: States.none,
-        rateStatus: States.none
+        rateStatus: States.none,
+        cancelStatus: States.none
       };
       return {
         ...state,

--- a/src/js/features/escrow/reducer.js
+++ b/src/js/features/escrow/reducer.js
@@ -20,7 +20,6 @@ const DEFAULT_STATE = {
   escrows: {},
   createEscrowStatus: States.none,
   releaseStatus: States.none,
-  payStatus: States.none,
   cancelStatus: States.none,
   rateStatus: States.none,
   fee: '0',
@@ -95,21 +94,23 @@ function reducer(state = DEFAULT_STATE, action) {
         escrows: escrowsClone
       };
     case PAY_ESCROW:
+      escrowsClone[escrowId].payStatus = States.pending;
       return {
         ...state,
-        payStatus: States.pending
+        escrows: escrowsClone
       };
     case PAY_ESCROW_SUCCEEDED:
+      escrowsClone[escrowId].payStatus = States.success;
       escrowsClone[escrowId].status = escrowStatus.PAID;
       return {
         ...state,
-        payStatus: States.success,
         escrows: escrowsClone
       };
     case PAY_ESCROW_FAILED:
+      escrowsClone[escrowId].payStatus = States.failed;
       return {
         ...state,
-        payStatus: States.failed
+        escrows: escrowsClone
       };
     case CREATE_ESCROW:
       return {

--- a/src/js/features/escrow/reducer.js
+++ b/src/js/features/escrow/reducer.js
@@ -19,7 +19,6 @@ import merge from 'merge';
 const DEFAULT_STATE = {
   escrows: {},
   createEscrowStatus: States.none,
-  releaseStatus: States.none,
   cancelStatus: States.none,
   rateStatus: States.none,
   fee: '0',
@@ -76,21 +75,22 @@ function reducer(state = DEFAULT_STATE, action) {
       };
     }
     case RELEASE_ESCROW:
+      escrowsClone[escrowId].releaseStatus = States.pending;
       return {
         ...state,
-        releaseStatus: States.pending
+        escrows: escrowsClone
       };
     case RELEASE_ESCROW_SUCCEEDED:
+      escrowsClone[escrowId].releaseStatus = States.success;
       escrowsClone[escrowId].status = escrowStatus.RELEASED;
       return {
         ...state,
-        releaseStatus: States.success,
         escrows: escrowsClone
       };
     case RELEASE_ESCROW_FAILED:
+      escrowsClone[escrowId].releaseStatus = States.failed;
       return {
         ...state,
-        releaseStatus: States.failed,
         escrows: escrowsClone
       };
     case PAY_ESCROW:
@@ -246,7 +246,7 @@ function reducer(state = DEFAULT_STATE, action) {
     case CLEAR_CHANGED_ESCROW:
       return {
         ...state,
-        chnagedEscrow: null
+        changedEscrow: null
       };
     case RESET_STATUS:
       escrowsClone[escrowId] = {

--- a/src/js/features/escrow/reducer.js
+++ b/src/js/features/escrow/reducer.js
@@ -19,7 +19,6 @@ import merge from 'merge';
 const DEFAULT_STATE = {
   escrows: {},
   createEscrowStatus: States.none,
-  rateStatus: States.none,
   fee: '0',
   newEscrow: null,
   changedEscrow: null
@@ -185,32 +184,32 @@ function reducer(state = DEFAULT_STATE, action) {
     case RATE_TRANSACTION:
       escrowsClone[action.escrowId] = {
         ...escrowsClone[action.escrowId],
-        rating: action.rating
+        rating: action.rating,
+        rateStatus: States.pending
       };
       return {
         ...state,
-        rateStatus: States.pending,
         escrows: escrowsClone
       };
     case RATE_TRANSACTION_SUCCEEDED: {
       escrowsClone[action.escrowId] = {
         ...escrowsClone[action.escrowId],
-        rating: action.rating
+        rating: action.rating,
+        rateStatus: States.success
       };
       return {
         ...state,
-        rateStatus: States.success,
         escrows: escrowsClone
       };
     }
     case RATE_TRANSACTION_FAILED:
       escrowsClone[action.escrowId] = {
         ...escrowsClone[action.escrowId],
-        rating: 0
+        rating: 0,
+        rateStatus: States.failed
       };
       return {
         ...state,
-        rateStatus: States.failed,
         escrows: escrowsClone
       };
     case ESCROW_EVENT_RECEIVED:

--- a/src/js/features/escrow/selectors.js
+++ b/src/js/features/escrow/selectors.js
@@ -9,8 +9,6 @@ export const getCreateEscrowStatus = state => state.escrow.createEscrowStatus;
 
 export const getCreateEscrowId = state => state.escrow.createEscrowId;
 
-export const getRatingStatus = state => state.escrow.rateStatus;
-
 export const getTrades = (state, userAddress, offers) => {
   const escrows = state.escrow.escrows || {};
   return Object.values(escrows).filter(escrow => addressCompare(escrow.buyer, userAddress) || offers.find(x => x.toString() === escrow.offerId.toString()) !== undefined)

--- a/src/js/features/escrow/selectors.js
+++ b/src/js/features/escrow/selectors.js
@@ -9,8 +9,6 @@ export const getCreateEscrowStatus = state => state.escrow.createEscrowStatus;
 
 export const getReleaseEscrowStatus = state => state.escrow.releaseStatus;
 
-export const getPaidEscrowStatus = state => state.escrow.payStatus;
-
 export const getCancelEscrowStatus = state => state.escrow.cancelStatus;
 
 export const getCreateEscrowId = state => state.escrow.createEscrowId;

--- a/src/js/features/escrow/selectors.js
+++ b/src/js/features/escrow/selectors.js
@@ -7,8 +7,6 @@ const unimportantStates = [tradeStates.canceled, tradeStates.expired, tradeState
 
 export const getCreateEscrowStatus = state => state.escrow.createEscrowStatus;
 
-export const getFundEscrowStatus = state => state.escrow.fundEscrowStatus;
-
 export const getReleaseEscrowStatus = state => state.escrow.releaseStatus;
 
 export const getPaidEscrowStatus = state => state.escrow.payStatus;

--- a/src/js/features/escrow/selectors.js
+++ b/src/js/features/escrow/selectors.js
@@ -7,8 +7,6 @@ const unimportantStates = [tradeStates.canceled, tradeStates.expired, tradeState
 
 export const getCreateEscrowStatus = state => state.escrow.createEscrowStatus;
 
-export const getReleaseEscrowStatus = state => state.escrow.releaseStatus;
-
 export const getCancelEscrowStatus = state => state.escrow.cancelStatus;
 
 export const getCreateEscrowId = state => state.escrow.createEscrowId;

--- a/src/js/features/escrow/selectors.js
+++ b/src/js/features/escrow/selectors.js
@@ -7,8 +7,6 @@ const unimportantStates = [tradeStates.canceled, tradeStates.expired, tradeState
 
 export const getCreateEscrowStatus = state => state.escrow.createEscrowStatus;
 
-export const getCancelEscrowStatus = state => state.escrow.cancelStatus;
-
 export const getCreateEscrowId = state => state.escrow.createEscrowId;
 
 export const getRatingStatus = state => state.escrow.rateStatus;

--- a/src/js/pages/Escrow/components/CardEscrowBuyer.jsx
+++ b/src/js/pages/Escrow/components/CardEscrowBuyer.jsx
@@ -103,10 +103,10 @@ PreFund.propTypes = {
 
 class CardEscrowBuyer extends Component {
   render(){
-    const {trade, payStatus, payAction, rateTransaction, arbitrationDetails, rateStatus} = this.props;
+    const {trade, payAction, rateTransaction, arbitrationDetails, rateStatus} = this.props;
 
-    const showLoading = payStatus === States.pending;
-    const showWaiting = payStatus === States.success || trade.status === escrow.helpers.tradeStates.released;
+    const showLoading = trade.payStatus === States.pending;
+    const showWaiting = trade.payStatus === States.success || trade.status === escrow.helpers.tradeStates.released;
 
     let component;
     if (showLoading) {
@@ -147,7 +147,6 @@ class CardEscrowBuyer extends Component {
 
 CardEscrowBuyer.propTypes = {
   trade: PropTypes.object,
-  payStatus: PropTypes.string,
   rateStatus: PropTypes.string,
   payAction: PropTypes.func,
   rateTransaction: PropTypes.func,

--- a/src/js/pages/Escrow/components/CardEscrowBuyer.jsx
+++ b/src/js/pages/Escrow/components/CardEscrowBuyer.jsx
@@ -103,7 +103,7 @@ PreFund.propTypes = {
 
 class CardEscrowBuyer extends Component {
   render(){
-    const {trade, payAction, rateTransaction, arbitrationDetails, rateStatus} = this.props;
+    const {trade, payAction, rateTransaction, arbitrationDetails} = this.props;
 
     const showLoading = trade.payStatus === States.pending;
     const showWaiting = trade.payStatus === States.success || trade.status === escrow.helpers.tradeStates.released;
@@ -124,7 +124,7 @@ class CardEscrowBuyer extends Component {
         component = <Unreleased/>;
       }
       if (trade.status === escrow.helpers.tradeStates.released) {
-        component = <Done trade={trade} rateTransaction={rateTransaction} rateStatus={rateStatus}/>;
+        component = <Done trade={trade} rateTransaction={rateTransaction} rateStatus={trade.rateStatus}/>;
       }
       if (trade.status === escrow.helpers.tradeStates.canceled) {
         component = <Canceled/>;
@@ -147,7 +147,6 @@ class CardEscrowBuyer extends Component {
 
 CardEscrowBuyer.propTypes = {
   trade: PropTypes.object,
-  rateStatus: PropTypes.string,
   payAction: PropTypes.func,
   rateTransaction: PropTypes.func,
   arbitrationDetails: PropTypes.object

--- a/src/js/pages/Escrow/components/CardEscrowSeller.jsx
+++ b/src/js/pages/Escrow/components/CardEscrowSeller.jsx
@@ -160,7 +160,7 @@ class CardEscrowSeller extends Component {
   render(){
     let step = this.state.step;
 
-    const {trade, fee, showApproveScreen, fundEscrow, releaseEscrow, releaseStatus, tokens, arbitrationDetails} = this.props;
+    const {trade, fee, showApproveScreen, fundEscrow, releaseEscrow, tokens, arbitrationDetails} = this.props;
     let showFundButton = this.props.showFundButton;
 
     if(trade.status === escrow.helpers.tradeStates.released || trade.status === escrow.helpers.tradeStates.paid){
@@ -170,8 +170,8 @@ class CardEscrowSeller extends Component {
     if (showFundButton) step = 2;
     if (trade.fundStatus === States.pending || (trade.mining && trade.status === escrow.helpers.tradeStates.waiting)) step = 3;
     if (trade.fundStatus === States.success) step = 4;
-    if (releaseStatus === States.pending || (trade.mining && (trade.status === escrow.helpers.tradeStates.funded || trade.status === escrow.helpers.tradeStates.paid))) step = 5;
-    if (releaseStatus === States.success || trade.status === escrow.helpers.tradeStates.released) step = 6;
+    if (trade.releaseStatus === States.pending || (trade.mining && (trade.status === escrow.helpers.tradeStates.funded || trade.status === escrow.helpers.tradeStates.paid))) step = 5;
+    if (trade.releaseStatus === States.success || trade.status === escrow.helpers.tradeStates.released) step = 6;
     if (arbitrationDetails && arbitrationDetails.open && arbitrationDetails.result.toString() === "0") step = 10;
     if (arbitrationDetails && arbitrationDetails.result.toString() !== ARBITRATION_UNSOLVED) step = 11;
 
@@ -224,7 +224,6 @@ CardEscrowSeller.propTypes = {
   fundEscrow: PropTypes.func,
   showFundButton: PropTypes.bool,
   releaseEscrow: PropTypes.func,
-  releaseStatus: PropTypes.string,
   arbitrationDetails: PropTypes.object
 };
 

--- a/src/js/pages/Escrow/components/CardEscrowSeller.jsx
+++ b/src/js/pages/Escrow/components/CardEscrowSeller.jsx
@@ -160,7 +160,7 @@ class CardEscrowSeller extends Component {
   render(){
     let step = this.state.step;
 
-    const {trade, fee, showApproveScreen, fundEscrow, releaseEscrow, fundStatus, releaseStatus, tokens, arbitrationDetails} = this.props;
+    const {trade, fee, showApproveScreen, fundEscrow, releaseEscrow, releaseStatus, tokens, arbitrationDetails} = this.props;
     let showFundButton = this.props.showFundButton;
 
     if(trade.status === escrow.helpers.tradeStates.released || trade.status === escrow.helpers.tradeStates.paid){
@@ -168,8 +168,8 @@ class CardEscrowSeller extends Component {
     }
 
     if (showFundButton) step = 2;
-    if (fundStatus === States.pending || (trade.mining && trade.status === escrow.helpers.tradeStates.waiting)) step = 3;
-    if (fundStatus === States.success) step = 4;
+    if (trade.fundStatus === States.pending || (trade.mining && trade.status === escrow.helpers.tradeStates.waiting)) step = 3;
+    if (trade.fundStatus === States.success) step = 4;
     if (releaseStatus === States.pending || (trade.mining && (trade.status === escrow.helpers.tradeStates.funded || trade.status === escrow.helpers.tradeStates.paid))) step = 5;
     if (releaseStatus === States.success || trade.status === escrow.helpers.tradeStates.released) step = 6;
     if (arbitrationDetails && arbitrationDetails.open && arbitrationDetails.result.toString() === "0") step = 10;
@@ -224,7 +224,6 @@ CardEscrowSeller.propTypes = {
   fundEscrow: PropTypes.func,
   showFundButton: PropTypes.bool,
   releaseEscrow: PropTypes.func,
-  fundStatus: PropTypes.string,
   releaseStatus: PropTypes.string,
   arbitrationDetails: PropTypes.object
 };

--- a/src/js/pages/Escrow/index.jsx
+++ b/src/js/pages/Escrow/index.jsx
@@ -101,7 +101,7 @@ class Escrow extends Component {
 
   render() {
     let {escrow, arbitration, fee, address, sntAllowance, tokenAllowance, loading, tokens, fundEscrow,
-      cancelEscrow, releaseEscrow, releaseStatus, rateStatus, payEscrow, rateTransaction, approvalTxHash,
+      cancelEscrow, releaseEscrow, rateStatus, payEscrow, rateTransaction, approvalTxHash,
       approvalError, cancelDispute} = this.props;
     const {showApproveFundsScreen} = this.state;
 
@@ -109,7 +109,7 @@ class Escrow extends Component {
       return <Loading page={true} />;
     }
 
-    if (releaseStatus === States.failed || escrow.payStatus === States.failed || rateStatus === States.failed || escrow.fundStatus === States.failed) {
+    if (escrow.releaseStatus === States.failed || escrow.payStatus === States.failed || rateStatus === States.failed || escrow.fundStatus === States.failed) {
       return <ErrorInformation transaction={true} cancel={this.props.resetStatus}/>;
     }
 
@@ -162,7 +162,6 @@ class Escrow extends Component {
                                       arbitrationDetails={arbitrationDetails} /> }
 
         { !isBuyer && <CardEscrowSeller tokens={tokens}
-                                        releaseStatus={releaseStatus}
                                         trade={escrow}
                                         fee={fee}
                                         showFundButton={showFundButton}
@@ -203,7 +202,6 @@ Escrow.propTypes = {
   fundEscrow: PropTypes.func,
   fundStatus: PropTypes.string,
   resetStatus: PropTypes.func,
-  releaseStatus: PropTypes.string,
   releaseEscrow: PropTypes.func,
   rateStatus: PropTypes.string,
   payEscrow: PropTypes.func,
@@ -238,7 +236,6 @@ const mapStateToProps = (state, props) => {
     approvalError: approval.selectors.error(state),
     tokens: network.selectors.getTokens(state),
     loading: cancelStatus === States.pending || ratingStatus === States.pending || approvalLoading || arbitrationLoading,
-    releaseStatus: escrow.selectors.getReleaseEscrowStatus(state),
     rateStatus: escrow.selectors.getRatingStatus(state),
     escrowEvents: events.selectors.getEscrowEvents(state),
     cancelStatus

--- a/src/js/pages/Escrow/index.jsx
+++ b/src/js/pages/Escrow/index.jsx
@@ -101,7 +101,7 @@ class Escrow extends Component {
 
   render() {
     let {escrow, arbitration, fee, address, sntAllowance, tokenAllowance, loading, tokens, fundEscrow,
-      cancelEscrow, releaseEscrow, releaseStatus, payStatus, rateStatus, payEscrow, rateTransaction, approvalTxHash,
+      cancelEscrow, releaseEscrow, releaseStatus, rateStatus, payEscrow, rateTransaction, approvalTxHash,
       approvalError, cancelDispute} = this.props;
     const {showApproveFundsScreen} = this.state;
 
@@ -109,7 +109,7 @@ class Escrow extends Component {
       return <Loading page={true} />;
     }
 
-    if (releaseStatus === States.failed || payStatus === States.failed || rateStatus === States.failed || escrow.fundStatus === States.failed) {
+    if (releaseStatus === States.failed || escrow.payStatus === States.failed || rateStatus === States.failed || escrow.fundStatus === States.failed) {
       return <ErrorInformation transaction={true} cancel={this.props.resetStatus}/>;
     }
 
@@ -156,7 +156,6 @@ class Escrow extends Component {
     return (
       <div className="escrow">
         { isBuyer && <CardEscrowBuyer trade={escrow}
-                                      payStatus={payStatus}
                                       payAction={payEscrow}
                                       rateTransaction={rateTransaction}
                                       rateStatus={rateStatus}
@@ -206,7 +205,6 @@ Escrow.propTypes = {
   resetStatus: PropTypes.func,
   releaseStatus: PropTypes.string,
   releaseEscrow: PropTypes.func,
-  payStatus: PropTypes.string,
   rateStatus: PropTypes.string,
   payEscrow: PropTypes.func,
   cancelStatus: PropTypes.string,
@@ -241,7 +239,6 @@ const mapStateToProps = (state, props) => {
     tokens: network.selectors.getTokens(state),
     loading: cancelStatus === States.pending || ratingStatus === States.pending || approvalLoading || arbitrationLoading,
     releaseStatus: escrow.selectors.getReleaseEscrowStatus(state),
-    payStatus: escrow.selectors.getPaidEscrowStatus(state),
     rateStatus: escrow.selectors.getRatingStatus(state),
     escrowEvents: events.selectors.getEscrowEvents(state),
     cancelStatus

--- a/src/js/pages/Escrow/index.jsx
+++ b/src/js/pages/Escrow/index.jsx
@@ -205,7 +205,6 @@ Escrow.propTypes = {
   releaseEscrow: PropTypes.func,
   rateStatus: PropTypes.string,
   payEscrow: PropTypes.func,
-  cancelStatus: PropTypes.string,
   approvalTxHash: PropTypes.string,
   cancelEscrow: PropTypes.func,
   cancelDispute: PropTypes.func,
@@ -218,16 +217,16 @@ Escrow.propTypes = {
 };
 
 const mapStateToProps = (state, props) => {
-  const cancelStatus = escrow.selectors.getCancelEscrowStatus(state);
   const approvalLoading = approval.selectors.isLoading(state);
   const arbitrationLoading = arbitration.selectors.isLoading(state);
   const ratingStatus = escrow.selectors.getRatingStatus(state);
   const escrowId = props.match.params.id.toString();
+  const theEscrow = escrow.selectors.getEscrowById(state, escrowId);
 
   return {
     address: network.selectors.getAddress(state) || "",
     escrowId:  escrowId,
-    escrow: escrow.selectors.getEscrowById(state, escrowId),
+    escrow: theEscrow,
     arbitration: arbitration.selectors.getArbitration(state) || {},
     fee: escrow.selectors.getFee(state),
     sntAllowance: approval.selectors.getSNTAllowance(state),
@@ -235,10 +234,9 @@ const mapStateToProps = (state, props) => {
     approvalTxHash: approval.selectors.txHash(state),
     approvalError: approval.selectors.error(state),
     tokens: network.selectors.getTokens(state),
-    loading: cancelStatus === States.pending || ratingStatus === States.pending || approvalLoading || arbitrationLoading,
+    loading: (theEscrow && theEscrow.cancelStatus === States.pending) || ratingStatus === States.pending || approvalLoading || arbitrationLoading,
     rateStatus: escrow.selectors.getRatingStatus(state),
-    escrowEvents: events.selectors.getEscrowEvents(state),
-    cancelStatus
+    escrowEvents: events.selectors.getEscrowEvents(state)
   };
 };
 

--- a/src/js/pages/Escrow/index.jsx
+++ b/src/js/pages/Escrow/index.jsx
@@ -101,7 +101,7 @@ class Escrow extends Component {
 
   render() {
     let {escrow, arbitration, fee, address, sntAllowance, tokenAllowance, loading, tokens, fundEscrow,
-      cancelEscrow, releaseEscrow, rateStatus, payEscrow, rateTransaction, approvalTxHash,
+      cancelEscrow, releaseEscrow, payEscrow, rateTransaction, approvalTxHash,
       approvalError, cancelDispute} = this.props;
     const {showApproveFundsScreen} = this.state;
 
@@ -109,7 +109,7 @@ class Escrow extends Component {
       return <Loading page={true} />;
     }
 
-    if (escrow.releaseStatus === States.failed || escrow.payStatus === States.failed || rateStatus === States.failed || escrow.fundStatus === States.failed) {
+    if (escrow.releaseStatus === States.failed || escrow.payStatus === States.failed || escrow.rateStatus === States.failed || escrow.fundStatus === States.failed) {
       return <ErrorInformation transaction={true} cancel={this.props.resetStatus}/>;
     }
 
@@ -158,7 +158,6 @@ class Escrow extends Component {
         { isBuyer && <CardEscrowBuyer trade={escrow}
                                       payAction={payEscrow}
                                       rateTransaction={rateTransaction}
-                                      rateStatus={rateStatus}
                                       arbitrationDetails={arbitrationDetails} /> }
 
         { !isBuyer && <CardEscrowSeller tokens={tokens}
@@ -203,7 +202,6 @@ Escrow.propTypes = {
   fundStatus: PropTypes.string,
   resetStatus: PropTypes.func,
   releaseEscrow: PropTypes.func,
-  rateStatus: PropTypes.string,
   payEscrow: PropTypes.func,
   approvalTxHash: PropTypes.string,
   cancelEscrow: PropTypes.func,
@@ -219,7 +217,6 @@ Escrow.propTypes = {
 const mapStateToProps = (state, props) => {
   const approvalLoading = approval.selectors.isLoading(state);
   const arbitrationLoading = arbitration.selectors.isLoading(state);
-  const ratingStatus = escrow.selectors.getRatingStatus(state);
   const escrowId = props.match.params.id.toString();
   const theEscrow = escrow.selectors.getEscrowById(state, escrowId);
 
@@ -234,8 +231,7 @@ const mapStateToProps = (state, props) => {
     approvalTxHash: approval.selectors.txHash(state),
     approvalError: approval.selectors.error(state),
     tokens: network.selectors.getTokens(state),
-    loading: (theEscrow && theEscrow.cancelStatus === States.pending) || ratingStatus === States.pending || approvalLoading || arbitrationLoading,
-    rateStatus: escrow.selectors.getRatingStatus(state),
+    loading: (theEscrow && theEscrow.cancelStatus === States.pending) || theEscrow.rateStatus === States.pending || approvalLoading || arbitrationLoading,
     escrowEvents: events.selectors.getEscrowEvents(state)
   };
 };

--- a/src/js/pages/Escrow/index.jsx
+++ b/src/js/pages/Escrow/index.jsx
@@ -100,18 +100,19 @@ class Escrow extends Component {
   };
 
   render() {
-    let {escrow, arbitration, fee, address, sntAllowance, tokenAllowance, loading, tokens, fundEscrow, fundStatus,
-      cancelEscrow, releaseEscrow, releaseStatus, payStatus, rateStatus, payEscrow, rateTransaction, approvalTxHash, 
+    let {escrow, arbitration, fee, address, sntAllowance, tokenAllowance, loading, tokens, fundEscrow,
+      cancelEscrow, releaseEscrow, releaseStatus, payStatus, rateStatus, payEscrow, rateTransaction, approvalTxHash,
       approvalError, cancelDispute} = this.props;
     const {showApproveFundsScreen} = this.state;
-
-    if (releaseStatus === States.failed || payStatus === States.failed || rateStatus === States.failed || fundStatus === States.failed) {
-      return <ErrorInformation transaction={true} cancel={this.props.resetStatus}/>;
-    }
 
     if(!escrow || (!sntAllowance && sntAllowance !== 0) || !arbitration || !arbitration.arbitration) {
       return <Loading page={true} />;
     }
+
+    if (releaseStatus === States.failed || payStatus === States.failed || rateStatus === States.failed || escrow.fundStatus === States.failed) {
+      return <ErrorInformation transaction={true} cancel={this.props.resetStatus}/>;
+    }
+
     if(loading) return <Loading mining={true} txHash={escrow.txHash || approvalTxHash}/>;
 
     const arbitrationDetails = arbitration.arbitration;
@@ -161,8 +162,7 @@ class Escrow extends Component {
                                       rateStatus={rateStatus}
                                       arbitrationDetails={arbitrationDetails} /> }
 
-        { !isBuyer && <CardEscrowSeller  fundStatus={fundStatus}
-                                        tokens={tokens}
+        { !isBuyer && <CardEscrowSeller tokens={tokens}
                                         releaseStatus={releaseStatus}
                                         trade={escrow}
                                         fee={fee}
@@ -227,7 +227,7 @@ const mapStateToProps = (state, props) => {
   const arbitrationLoading = arbitration.selectors.isLoading(state);
   const ratingStatus = escrow.selectors.getRatingStatus(state);
   const escrowId = props.match.params.id.toString();
-  
+
   return {
     address: network.selectors.getAddress(state) || "",
     escrowId:  escrowId,
@@ -240,7 +240,6 @@ const mapStateToProps = (state, props) => {
     approvalError: approval.selectors.error(state),
     tokens: network.selectors.getTokens(state),
     loading: cancelStatus === States.pending || ratingStatus === States.pending || approvalLoading || arbitrationLoading,
-    fundStatus: escrow.selectors.getFundEscrowStatus(state),
     releaseStatus: escrow.selectors.getReleaseEscrowStatus(state),
     payStatus: escrow.selectors.getPaidEscrowStatus(state),
     rateStatus: escrow.selectors.getRatingStatus(state),


### PR DESCRIPTION
Big clean up so that the escrow states are inside the escrows instead of being "global", that way, it is way easier to manage changing the escrow, so we will no longer have the issue of an escrow being completed and the others are still completed and also errors are also gonna perpetuate correctly in the right escrow.