### PR TITLE
feat: show a message when the trade asset price is 10% lower

### DIFF
--- a/src/js/features/prices/selectors.js
+++ b/src/js/features/prices/selectors.js
@@ -1,5 +1,12 @@
 export const getPrices = state => state.prices;
 
+export const getAssetPrice = (state, assetSymbol) => {
+  if (!assetSymbol) {
+    return null;
+  }
+  return state.prices[assetSymbol];
+};
+
 export const hasPrices = state => {
   return state.prices.ETH !== undefined;
 };

--- a/src/js/pages/Escrow/components/EscrowDetail.jsx
+++ b/src/js/pages/Escrow/components/EscrowDetail.jsx
@@ -4,6 +4,7 @@ import {faQuestionCircle} from "@fortawesome/free-solid-svg-icons";
 import PropTypes from 'prop-types';
 import RoundedIcon from "../../../ui/RoundedIcon";
 import moment from "moment";
+import {tradeStates} from '../../../features/escrow/helpers';
 
 const PERCENTAGE_THRESHOLD = 10; // If asset price is 10% different than the real price, show the warning
 
@@ -19,7 +20,7 @@ const EscrowDetail = ({escrow, currentPrice}) => {
       <p className="text-dark m-0">{(escrow.tokenAmount * escrow.assetPrice / 100).toFixed(2)} {escrow.offer.currency} for {escrow.tokenAmount} {escrow.token.symbol}</p>
       <p className="text-dark m-0">{escrow.token.symbol} Price = {escrowAssetPrice} {escrow.offer.currency}</p>
       {escrow.expirationTime && escrow.expirationTime !== '0' && <p className="text-dark m-0">Expiration time: {moment(escrow.expirationTime * 1000).calendar()}</p>}
-      {currentPriceForCurrency && escrowAssetPrice * ((PERCENTAGE_THRESHOLD + 100) / 100) < currentPriceForCurrency &&
+      {escrow.status === tradeStates.waiting && currentPriceForCurrency && escrowAssetPrice * ((PERCENTAGE_THRESHOLD + 100) / 100) < currentPriceForCurrency &&
       <Fragment>
         <p className="text-danger font-weight-bold mb-0">The current price for {escrow.token.symbol} is {currentPriceForCurrency} {escrow.offer.currency}, which is {PERCENTAGE_THRESHOLD}% above the price for this trade</p>
         <p className="text-danger mb-1">Double-check whether you really want to go through with this trade</p>

--- a/src/js/pages/Escrow/components/EscrowDetail.jsx
+++ b/src/js/pages/Escrow/components/EscrowDetail.jsx
@@ -1,25 +1,37 @@
-import React from 'react';
+import React, {Fragment} from 'react';
 import {Row, Col} from 'reactstrap';
 import {faQuestionCircle} from "@fortawesome/free-solid-svg-icons";
 import PropTypes from 'prop-types';
 import RoundedIcon from "../../../ui/RoundedIcon";
 import moment from "moment";
 
-const EscrowDetail = ({escrow}) => <Row className="mt-4">
+const PERCENTAGE_THRESHOLD = 10; // If asset price is 10% different than the real price, show the warning
+
+const EscrowDetail = ({escrow, currentPrice}) => {
+  const currentPriceForCurrency = parseFloat(currentPrice ? currentPrice[escrow.offer.currency] : null);
+  const escrowAssetPrice = escrow.assetPrice / 100;
+  return (<Row className="mt-4">
     <Col xs="2">
       <RoundedIcon icon={faQuestionCircle} bgColor="grey"/>
     </Col>
     <Col xs="10">
       <h5 className="m-0">Trade details</h5>
       <p className="text-dark m-0">{(escrow.tokenAmount * escrow.assetPrice / 100).toFixed(2)} {escrow.offer.currency} for {escrow.tokenAmount} {escrow.token.symbol}</p>
-      <p className="text-dark m-0">{escrow.token.symbol} Price = {escrow.assetPrice / 100} {escrow.offer.currency}</p>
+      <p className="text-dark m-0">{escrow.token.symbol} Price = {escrowAssetPrice} {escrow.offer.currency}</p>
       {escrow.expirationTime && escrow.expirationTime !== '0' && <p className="text-dark m-0">Expiration time: {moment(escrow.expirationTime * 1000).calendar()}</p>}
-    </Col>
-  </Row>;
+      {currentPriceForCurrency && escrowAssetPrice * ((PERCENTAGE_THRESHOLD + 100) / 100) < currentPriceForCurrency &&
+      <Fragment>
+        <p className="text-danger font-weight-bold mb-0">The current price for {escrow.token.symbol} is {currentPriceForCurrency} {escrow.offer.currency}, which is {PERCENTAGE_THRESHOLD}% above the price for this trade</p>
+        <p className="text-danger mb-1">Double-check whether you really want to go through with this trade</p>
+      </Fragment>}
+      </Col>
+  </Row>);
+};
 
 
 EscrowDetail.propTypes = {
-  escrow: PropTypes.object
+  escrow: PropTypes.object,
+  currentPrice: PropTypes.object
 };
 
 export default EscrowDetail;

--- a/src/js/pages/Escrow/index.jsx
+++ b/src/js/pages/Escrow/index.jsx
@@ -24,6 +24,7 @@ import network from '../../features/network';
 import approval from '../../features/approval';
 import arbitration from '../../features/arbitration';
 import events from '../../features/events';
+import prices from '../../features/prices';
 
 import "./index.scss";
 import { ARBITRATION_UNSOLVED } from '../../features/arbitration/constants';
@@ -175,7 +176,7 @@ class Escrow extends Component {
                                         releaseEscrow={releaseEscrow}
                                         arbitrationDetails={arbitrationDetails} /> }
 
-        <EscrowDetail escrow={escrow} />
+        <EscrowDetail escrow={escrow} currentPrice={this.props.assetCurrentPrice} />
         <OpenChat statusContactCode={isBuyer ? escrow.seller.statusContactCode : escrow.buyerInfo.statusContactCode } withBuyer={!isBuyer} />
         <Profile withBuyer={!isBuyer} address={isBuyer ? escrow.offer.owner : escrow.buyer} />
         <hr />
@@ -218,6 +219,7 @@ Escrow.propTypes = {
   loadArbitration: PropTypes.func,
   watchEscrow: PropTypes.func,
   escrowEvents: PropTypes.object,
+  assetCurrentPrice: PropTypes.object,
   lastActivity: PropTypes.number,
   getLastActivity: PropTypes.func,
   ethBalance: PropTypes.string,
@@ -244,6 +246,7 @@ const mapStateToProps = (state, props) => {
     loading: (theEscrow && (theEscrow.cancelStatus === States.pending || theEscrow.rateStatus === States.pending)) || approvalLoading || arbitrationLoading,
     escrowEvents: events.selectors.getEscrowEvents(state),
     lastActivity: escrowF.selectors.getLastActivity(state),
+    assetCurrentPrice: (theEscrow && theEscrow.token) ? prices.selectors.getAssetPrice(state, theEscrow.token.symbol) : null,
     gasPrice: network.selectors.getNetworkGasPrice(state),
     ethBalance: network.selectors.getBalance(state, 'ETH')
   };


### PR DESCRIPTION
Percent can be easily changed
I'm not sure if I need to put the margin in my calculations? Like, what if the seller put amunally -10% 
margin, do we still put the warning?

Bogus data btw, ETH is not really 100 :P
![image](https://user-images.githubusercontent.com/11926403/58814969-bebbbd80-85f4-11e9-9031-7eaee458a531.png)
