### PR TITLE
feat: decouple metadata from escrow, and ask for signatures in escrow creation

### DIFF
--- a/contracts/common/MessageSigned.sol
+++ b/contracts/common/MessageSigned.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.7;
+pragma solidity >=0.5.0 <0.6.0;
 
 /** 
  * @notice Uses ethereum signed messages
@@ -55,6 +55,7 @@ contract MessageSigned {
         pure
         returns (uint8 v, bytes32 r, bytes32 s)
     {
+        require(_signature.length == 65, "Bad signature length");
         // The signature format is a compact form of:
         //   {bytes32 r}{bytes32 s}{uint8 v}
         // Compact means, uint8 is not padded to 32 bytes.
@@ -68,8 +69,10 @@ contract MessageSigned {
             // use the second best option, 'and'
             v := and(mload(add(_signature, 65)), 0xff)
         }
-
-        require(v == 27 || v == 28, "Bad signature");
+        if (v < 27) {
+            v += 27;
+        }
+        require(v == 27 || v == 28, "Bad signature version");
     }
     
 }

--- a/contracts/teller-network/Escrow.sol
+++ b/contracts/teller-network/Escrow.sol
@@ -146,9 +146,10 @@ contract Escrow is Pausable, MessageSigned, Fees, Arbitrable, RelayRecipient {
         uint _assetPrice,
         bytes memory _statusContactCode,
         string memory _location,
-        string memory _username
+        string memory _username,
+        uint _nonce
     ) public whenNotPaused returns(uint escrowId) {
-        address payable _buyer = metadataStore.addOrUpdateUser(_signature, _statusContactCode, _location, _username);
+        address payable _buyer = metadataStore.addOrUpdateUser(_signature, _statusContactCode, _location, _username, _nonce);
         lastActivity[_buyer] = block.timestamp;
         escrowId = _createTransaction(_buyer, _offerId, _tradeAmount, _tradeType, _assetPrice);
     }

--- a/contracts/teller-network/Escrow.sol
+++ b/contracts/teller-network/Escrow.sol
@@ -150,7 +150,7 @@ contract Escrow is Pausable, MessageSigned, Fees, Arbitrable, RelayRecipient {
     ) public whenNotPaused returns(uint escrowId) {
         address payable _buyer = metadataStore.addOrUpdateUser(_signature, _statusContactCode, _location, _username);
         lastActivity[_buyer] = block.timestamp;
-        escrowId = createTransaction(_buyer, _offerId, _tradeAmount, _tradeType, _assetPrice);
+        escrowId = _createTransaction(_buyer, _offerId, _tradeAmount, _tradeType, _assetPrice);
     }
 
     /**

--- a/contracts/teller-network/MetadataStore.sol
+++ b/contracts/teller-network/MetadataStore.sol
@@ -1,14 +1,13 @@
 pragma solidity ^0.5.8;
 
 import "./License.sol";
-import "../common/Ownable.sol";
 import "../common/MessageSigned.sol";
 
 /**
 * @title MetadataStore
 * @dev Metadata store
 */
-contract MetadataStore is Ownable, MessageSigned {
+contract MetadataStore is MessageSigned {
 
     enum PaymentMethods {Cash,BankTransfer,InternationalWire}
 
@@ -80,11 +79,6 @@ contract MetadataStore is Ownable, MessageSigned {
         license = _license;
         arbitrationLicense = _arbitrationLicense;
     }
-
-    function setEscrowAddress(address _escrow) public onlyOwner {
-        escrow = _escrow;
-    }
-
 
     mapping(address => uint) public user_nonce;
 

--- a/contracts/teller-network/MetadataStore.sol
+++ b/contracts/teller-network/MetadataStore.sol
@@ -171,7 +171,6 @@ contract MetadataStore is Ownable, MessageSigned {
     */
     function addOffer(
         address _asset,
-        bytes memory _signature,
         bytes memory _statusContactCode,
         string memory _location,
         string memory _currency,
@@ -187,16 +186,16 @@ contract MetadataStore is Ownable, MessageSigned {
         require(_margin >= -100, "Margin too low");
         require(msg.sender != _arbitrator, "Cannot arbitrate own offers");
 
-        address payable _user = this.addOrUpdateUser(_signature, _statusContactCode, _location, _username);
+        _addOrUpdateUser(msg.sender, _statusContactCode, _location, _username);
 
-        Offer memory offer = Offer(_margin, _paymentMethods, _asset, _currency, _user, _arbitrator);
+        Offer memory offer = Offer(_margin, _paymentMethods, _asset, _currency, msg.sender, _arbitrator);
 
         uint256 offerId = offers.push(offer) - 1;
         offerWhitelist[msg.sender][offerId] = true;
         addressToOffers[msg.sender].push(offerId);
 
         emit OfferAdded(
-            _user, offerId, _asset, _statusContactCode, _location, _currency, _username, _paymentMethods, _margin
+            msg.sender, offerId, _asset, _statusContactCode, _location, _currency, _username, _paymentMethods, _margin
         );
     }
 

--- a/embarkConfig/contracts.js
+++ b/embarkConfig/contracts.js
@@ -92,7 +92,6 @@ module.exports = {
         args: ["$SellerLicense", "$ArbitrationLicense", "$MetadataStore", "$SNT", BURN_ADDRESS, FEE_AMOUNT],
         deps: ['RelayHub'],
         onDeploy: [
-          "MetadataStore.methods.setEscrowAddress('$Escrow').send()",
           "Escrow.methods.setRelayHubAddress('$RelayHub').send()",
           "RelayHub.methods.depositFor('$Escrow').send({value: 1000000000000000000})"
         ]
@@ -271,7 +270,6 @@ module.exports = {
         args: ["$SellerLicense", "$ArbitrationLicense", "$MetadataStore", "$SNT", BURN_ADDRESS, FEE_AMOUNT],
         deps: ['RelayHub'],
         onDeploy: [
-          "MetadataStore.methods.setEscrowAddress('$Escrow').send()",
           "Escrow.methods.setRelayHubAddress('$RelayHub').send()",
           "RelayHub.methods.depositFor('$Escrow').send({value: 300000000000000000})"
         ]

--- a/src/js/features/escrow/actions.js
+++ b/src/js/features/escrow/actions.js
@@ -11,14 +11,15 @@ import Escrow from '../../../embarkArtifacts/contracts/Escrow';
 import { toTokenDecimals } from '../../utils/numbers';
 import { zeroAddress } from '../../utils/address';
 
-export const createEscrow = (buyerAddress, username, tradeAmount, assetPrice, statusContactCode, offer) => {
+export const createEscrow = (signature, username, tradeAmount, assetPrice, statusContactCode, offer, nonce) => {
   tradeAmount = toTokenDecimals(tradeAmount, offer.token.decimals);
   return {
     type: CREATE_ESCROW,
     user: {
       statusContactCode,
       username,
-      buyerAddress
+      signature,
+      nonce
     },
     escrow: {
       tradeAmount,

--- a/src/js/features/escrow/saga.js
+++ b/src/js/features/escrow/saga.js
@@ -26,14 +26,16 @@ import {ADD_OFFER_SUCCEEDED} from "../metadata/constants";
 
 export function *createEscrow({user, escrow}) {
   const toSend = Escrow.methods.create(
-    user.buyerAddress,
+    user.signature,
     escrow.offerId,
     escrow.tradeAmount,
     1,
     escrow.assetPrice,
     user.statusContactCode,
     '',
-    user.username);
+    user.username,
+    user.nonce
+    );
   yield doTransaction(CREATE_ESCROW_PRE_SUCCESS, CREATE_ESCROW_SUCCEEDED, CREATE_ESCROW_FAILED, {user, escrow, toSend});
 }
 

--- a/src/js/features/metadata/actions.js
+++ b/src/js/features/metadata/actions.js
@@ -1,6 +1,7 @@
 import {
   LOAD, ADD_OFFER, RESET_ADD_OFFER_STATUS, SET_CURRENT_USER,
-  UPDATE_USER, RESET_UPDATE_USER_STATUS, LOAD_OFFERS, LOAD_USER
+  UPDATE_USER, RESET_UPDATE_USER_STATUS, LOAD_OFFERS, LOAD_USER,
+  SIGN_MESSAGE
 } from './constants';
 
 export const load = (address) => ({type: LOAD, address});
@@ -21,6 +22,12 @@ export const addOffer = (seller) => ({
     margin: seller.margin,
     arbitrator: seller.arbitrator
   }
+});
+
+export const signMessage = (username, statusContactCode) => ({
+  type: SIGN_MESSAGE,
+  statusContactCode,
+  username
 });
 
 export const setCurrentUser = (currentUser) => ({

--- a/src/js/features/metadata/constants.js
+++ b/src/js/features/metadata/constants.js
@@ -24,6 +24,10 @@ export const UPDATE_USER_SUCCEEDED = 'METADATA/UPDATE_USER/SUCCEEDED';
 export const UPDATE_USER_FAILED = 'METADATA/UPDATE_USER/FAILED';
 export const UPDATE_USER_PRE_SUCCESS = 'METADATA/UPDATE_USER/PRE_SUCCESS';
 
+export const SIGN_MESSAGE = 'METADATA/SIGN_MESSAGE';
+export const SIGN_MESSAGE_SUCCEEDED = 'METADATA/SIGN_MESSAGE_SUCCEEDED';
+export const SIGN_MESSAGE_FAILED = 'METADATA/SIGN_MESSAGE_FAILED';
+
 // Mapping
 export const PAYMENT_METHODS = ['Cash (In person)', 'Bank Transfer', 'International wire'];
 export const SORT_TYPES = ['Top rated', 'Most recent'];

--- a/src/js/features/metadata/reducer.js
+++ b/src/js/features/metadata/reducer.js
@@ -2,7 +2,8 @@ import {
   LOAD_OFFERS_SUCCEEDED, LOAD_USER_SUCCEEDED,
   ADD_OFFER, ADD_OFFER_SUCCEEDED, ADD_OFFER_FAILED, RESET_ADD_OFFER_STATUS, ADD_OFFER_PRE_SUCCESS,
   UPDATE_USER, UPDATE_USER_SUCCEEDED, UPDATE_USER_FAILED, RESET_UPDATE_USER_STATUS,
-  LOAD_USER_LOCATION_SUCCEEDED, SET_CURRENT_USER, LOAD_USER_TRADE_NUMBER_SUCCEEDED
+  LOAD_USER_LOCATION_SUCCEEDED, SET_CURRENT_USER, LOAD_USER_TRADE_NUMBER_SUCCEEDED,
+  SIGN_MESSAGE, SIGN_MESSAGE_SUCCEEDED, SIGN_MESSAGE_FAILED
 } from './constants';
 import {USER_RATING_SUCCEEDED, CREATE_ESCROW_SUCCEEDED} from '../escrow/constants';
 import { States } from '../../utils/transaction';
@@ -14,7 +15,9 @@ const DEFAULT_STATE = {
   addOfferTx: '',
   updateUserStatus: States.none,
   users: {},
-  offers: {}
+  offers: {},
+  signing: false,
+  signature: ''
 };
 
 function formatOffer(offer) {
@@ -27,6 +30,7 @@ function formatOffer(offer) {
   };
 }
 
+/*eslint-disable-next-line complexity */
 function reducer(state = DEFAULT_STATE, action) {
   switch (action.type) {
     case RESET_ADD_OFFER_STATUS:
@@ -150,6 +154,25 @@ function reducer(state = DEFAULT_STATE, action) {
     }
     case PURGE_STATE:
       return DEFAULT_STATE;
+    case SIGN_MESSAGE:
+      return {
+        ...state,
+        signing: true
+      };
+    case SIGN_MESSAGE_SUCCEEDED: 
+      return {
+        ...state,
+        signing: false,
+        signature: action.signature,
+        nonce: action.nonce
+      };
+    case SIGN_MESSAGE_FAILED: 
+      return {
+        ...state,
+        signing: false,
+        signature: "",
+        nonce: 0
+      };
     default:
       return state;
   }

--- a/src/js/features/metadata/selectors.js
+++ b/src/js/features/metadata/selectors.js
@@ -70,3 +70,9 @@ export const getUsersWithOffers = (state) => {
 export const getAllUsers = state => state.metadata.users;
 
 export const getAddOfferTx = state => state.metadata.addOfferTx;
+
+export const isSigning = state => state.metadata.signing;
+
+export const getSignature = state => state.metadata.signature;
+
+export const getNonce = state => state.metadata.nonce;

--- a/src/js/wizards/Buy/0_Contact/index.jsx
+++ b/src/js/wizards/Buy/0_Contact/index.jsx
@@ -22,6 +22,7 @@ class Contact extends Component {
     this.validate(props.username, props.statusContactCode);
     props.footer.enableNext();
     props.footer.onPageChange(() => {
+      props.signMessage(this.state.username, this.state.statusContactCode);
       props.setContactInfo({username: DOMPurify.sanitize(this.state.username), statusContactCode: DOMPurify.sanitize(this.state.statusContactCode)});
     });
   }
@@ -29,14 +30,11 @@ class Contact extends Component {
   componentDidMount() {
     if (this.props.profile && this.props.profile.username) {
       this.props.setContactInfo({username: DOMPurify.sanitize(this.props.profile.username), statusContactCode: DOMPurify.sanitize(this.props.profile.statusContactCode)});
-      // FIXME: infinite loop between this page and the next
-      setTimeout(() => {
-        this.props.wizard.next();
-      }, 500);
     } else {
       this.validate(this.props.username, this.props.statusContactCode);
-      this.setState({ready: true});
     }
+
+    this.setState({ready: true});
   }
 
   componentDidUpdate(prevProps) {
@@ -107,7 +105,8 @@ Contact.propTypes = {
   getContactCode: PropTypes.func,
   profile: PropTypes.object,
   resolveENSName: PropTypes.func,
-  ensError: PropTypes.string
+  ensError: PropTypes.string,
+  signMessage: PropTypes.func
 };
 
 const mapStateToProps = state => ({
@@ -124,6 +123,7 @@ export default connect(
   {
     setContactInfo: newBuy.actions.setContactInfo,
     getContactCode: network.actions.getContactCode,
-    resolveENSName: network.actions.resolveENSName
+    resolveENSName: network.actions.resolveENSName,
+    signMessage: metadata.actions.signMessage
   }
   )(withRouter(Contact));

--- a/src/js/wizards/Buy/0_Contact/index.jsx
+++ b/src/js/wizards/Buy/0_Contact/index.jsx
@@ -16,8 +16,7 @@ class Contact extends Component {
     super(props);
     this.state = {
       username: props.username,
-      statusContactCode: props.statusContactCode,
-      ready: false
+      statusContactCode: props.statusContactCode
     };
     this.validate(props.username, props.statusContactCode);
     props.footer.enableNext();
@@ -33,8 +32,6 @@ class Contact extends Component {
     } else {
       this.validate(this.props.username, this.props.statusContactCode);
     }
-
-    this.setState({ready: true});
   }
 
   componentDidUpdate(prevProps) {
@@ -77,9 +74,6 @@ class Contact extends Component {
   }
 
   render() {
-    if (!this.state.ready) {
-      return <Loading page/>;
-    }
     return (
       <EditContact isStatus={this.props.isStatus}
                    statusContactCode={this.state.statusContactCode}

--- a/src/js/wizards/Buy/1_Trade/index.jsx
+++ b/src/js/wizards/Buy/1_Trade/index.jsx
@@ -21,8 +21,7 @@ class Trade extends Component {
     this.state = {
       currencyQuantity: props.currencyQuantity,
       assetQuantity: props.assetQuantity,
-      disabled: true,
-      ready: false
+      disabled: true
     };
 
     props.footer.hide();
@@ -42,8 +41,6 @@ class Trade extends Component {
     this.props.loadOffers(this.props.offer.owner); // TODO Change this to only load the right offer
 
     this.getSellerBalance();
-
-    this.setState({ready: true});
   }
 
   getSellerBalance() {
@@ -111,7 +108,7 @@ class Trade extends Component {
   };
 
   render() {
-    if (!this.state.ready || !this.props.offer || !this.props.sellerBalance || this.props.isSigning) {
+    if (!this.props.offer || !this.props.sellerBalance || this.props.isSigning) {
       return <Loading page/>;
     }
 

--- a/src/js/wizards/Buy/1_Trade/index.jsx
+++ b/src/js/wizards/Buy/1_Trade/index.jsx
@@ -21,7 +21,8 @@ class Trade extends Component {
     this.state = {
       currencyQuantity: props.currencyQuantity,
       assetQuantity: props.assetQuantity,
-      disabled: true
+      disabled: true,
+      ready: false
     };
 
     props.footer.hide();
@@ -41,6 +42,8 @@ class Trade extends Component {
     this.props.loadOffers(this.props.offer.owner); // TODO Change this to only load the right offer
 
     this.getSellerBalance();
+
+    this.setState({ready: true});
   }
 
   getSellerBalance() {
@@ -108,7 +111,7 @@ class Trade extends Component {
   };
 
   render() {
-    if (!this.props.offer || !this.props.sellerBalance || this.props.isSigning) {
+    if (!this.state.ready || !this.props.offer || !this.props.sellerBalance || this.props.isSigning) {
       return <Loading page/>;
     }
 

--- a/test/escrow_spec.js
+++ b/test/escrow_spec.js
@@ -92,7 +92,7 @@ contract("Escrow", function() {
     expirationTime += 1000;
   };
 
-  let receipt, escrowId, escrowTokenId, _offerId, ethOfferId, tokenOfferId;
+  let receipt, escrowId, escrowTokenId, _offerId, ethOfferId, tokenOfferId, hash, signature;
 
   this.timeout(0);
 
@@ -109,16 +109,24 @@ contract("Escrow", function() {
     await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator});
     await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator2});
 
-    receipt  = await MetadataStore.methods.addOffer(TestUtils.zeroAddress, SellerLicense.address, "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
+    // generate signature
+    hash = await MetadataStore.methods.getDataHash("Iuri", "0x00", "London").call();
+    signature = await web3.eth.sign(hash, accounts[0]);
+
+    receipt  = await MetadataStore.methods.addOffer(TestUtils.zeroAddress, signature, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
     ethOfferId = receipt.events.OfferAdded.returnValues.offerId;
-    receipt  = await MetadataStore.methods.addOffer(StandardToken.options.address, SellerLicense.address, "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
+    receipt  = await MetadataStore.methods.addOffer(StandardToken.options.address, signature, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
     tokenOfferId = receipt.events.OfferAdded.returnValues.offerId;
   });
 
   describe("Creating a new escrow", async () => {
+
     it("Seller must be licensed to participate in escrow", async () => {
       try {
-        await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[8]});
+        hash = await MetadataStore.methods.getDataHash("L", [0], "U").call();
+        signature = await web3.eth.sign(hash, accounts[1]);
+
+        await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[8]});       
         assert.fail('should have reverted before');
       } catch (error) {
         assert.strictEqual(error.message, "VM Exception while processing transaction: revert Must participate in the trade");
@@ -126,7 +134,11 @@ contract("Escrow", function() {
     });
 
     it("Buyer can create escrow", async () => {
-      receipt = await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[1]});
+      // receipt = await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[1]});
+      hash = await MetadataStore.methods.getDataHash("U", License.address, "L").call();
+      signature = await web3.eth.sign(hash, accounts[1]);
+      
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, License.address, "L", "U").send({from: accounts[1]});      
       const created = receipt.events.Created;
       assert(!!created, "Created() not triggered");
       assert.equal(created.returnValues.offerId, ethOfferId, "Invalid offerId");
@@ -134,7 +146,9 @@ contract("Escrow", function() {
     });
 
     it("Seller should be able to create escrows", async () => {
-      receipt = await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[0]});
+      // receipt = await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[0]});
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, License.address, "L", "U").send({from: accounts[0]});
+
       const created = receipt.events.Created;
       assert(!!created, "Created() not triggered");
 
@@ -154,7 +168,7 @@ contract("Escrow", function() {
     });
 
     it("Seller should be able to fund escrow", async () => {
-      receipt = await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[0]});
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, License.address, "L", "U").send({from: accounts[0]});
       escrowId = receipt.events.Created.returnValues.escrowId;
 
       // Approve fee amount
@@ -181,7 +195,7 @@ contract("Escrow", function() {
 
       await StandardToken.methods.approve(Escrow.options.address, value).send({from: accounts[0]});
 
-      receipt = await Escrow.methods.create(accounts[1], tokenOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[0]});
+      receipt = await Escrow.methods.create(signature, tokenOfferId, 123, FIAT, 140, License.address, "L", "U").send({from: accounts[0]});
       const created = receipt.events.Created;
       assert(!!created, "Created() not triggered");
       escrowTokenId = receipt.events.Created.returnValues.escrowId;
@@ -269,7 +283,7 @@ contract("Escrow", function() {
     });
 
     it("A buyer can cancel an escrow that hasn't been funded yet", async () => {
-      receipt = await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[1]});
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, License.address, "L", "U").send({from: accounts[1]});
       receipt = await Escrow.methods.cancel(receipt.events.Created.returnValues.escrowId).send({from: accounts[1]});
       let Canceled = receipt.events.Canceled;
       assert(!!Canceled, "Canceled() not triggered");

--- a/test/escrow_spec.js
+++ b/test/escrow_spec.js
@@ -91,7 +91,7 @@ contract("Escrow", function() {
     expirationTime += 1000;
   };
 
-  let receipt, escrowId, escrowTokenId, _offerId, ethOfferId, tokenOfferId, hash, signature;
+  let receipt, escrowId, escrowTokenId, _offerId, ethOfferId, tokenOfferId, hash, signature, nonce;
 
   this.timeout(0);
 
@@ -108,10 +108,6 @@ contract("Escrow", function() {
     await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator});
     await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator2});
 
-    // generate signature
-    hash = await MetadataStore.methods.getDataHash("Iuri", "0x00", "London").call();
-    signature = await web3.eth.sign(hash, accounts[0]);
-
     receipt  = await MetadataStore.methods.addOffer(TestUtils.zeroAddress, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
     ethOfferId = receipt.events.OfferAdded.returnValues.offerId;
     receipt  = await MetadataStore.methods.addOffer(StandardToken.options.address, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
@@ -122,10 +118,11 @@ contract("Escrow", function() {
 
     it("Seller must be licensed to participate in escrow", async () => {
       try {
-        hash = await MetadataStore.methods.getDataHash("L", "0x00", "U").call();
+        hash = await MetadataStore.methods.getDataHash("U", "0x00").call({from: accounts[1]});
         signature = await web3.eth.sign(hash, accounts[1]);
+        nonce = await MetadataStore.methods.user_nonce(accounts[1]).call();
 
-        await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[8]});       
+        await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U", nonce).send({from: accounts[8]});       
         assert.fail('should have reverted before');
       } catch (error) {
         assert.strictEqual(error.message, "VM Exception while processing transaction: revert Must participate in the trade");
@@ -134,10 +131,11 @@ contract("Escrow", function() {
 
     it("Buyer can create escrow", async () => {
       // receipt = await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[1]});
-      hash = await MetadataStore.methods.getDataHash("U", "0x00", "L").call();
+      hash = await MetadataStore.methods.getDataHash("U", "0x00").call({from: accounts[1]});
       signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await MetadataStore.methods.user_nonce(accounts[1]).call();
       
-      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[1]});      
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U", nonce).send({from: accounts[1]});      
       const created = receipt.events.Created;
       assert(!!created, "Created() not triggered");
       assert.equal(created.returnValues.offerId, ethOfferId, "Invalid offerId");
@@ -145,8 +143,12 @@ contract("Escrow", function() {
     });
 
     it("Seller should be able to create escrows", async () => {
-      // receipt = await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[0]});
-      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[0]});
+      
+      hash = await MetadataStore.methods.getDataHash("U", "0x00").call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await MetadataStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U", nonce).send({from: accounts[0]});
 
       const created = receipt.events.Created;
       assert(!!created, "Created() not triggered");
@@ -167,7 +169,11 @@ contract("Escrow", function() {
     });
 
     it("Seller should be able to fund escrow", async () => {
-      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[0]});
+      hash = await MetadataStore.methods.getDataHash("U", "0x00").call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await MetadataStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U", nonce).send({from: accounts[0]});
       escrowId = receipt.events.Created.returnValues.escrowId;
 
       // Approve fee amount
@@ -194,7 +200,11 @@ contract("Escrow", function() {
 
       await StandardToken.methods.approve(Escrow.options.address, value).send({from: accounts[0]});
 
-      receipt = await Escrow.methods.create(signature, tokenOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[0]});
+      hash = await MetadataStore.methods.getDataHash("U", "0x00").call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await MetadataStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.create(signature, tokenOfferId, 123, FIAT, 140, "0x00", "L", "U", nonce).send({from: accounts[0]});
       const created = receipt.events.Created;
       assert(!!created, "Created() not triggered");
       escrowTokenId = receipt.events.Created.returnValues.escrowId;
@@ -282,7 +292,11 @@ contract("Escrow", function() {
     });
 
     it("A buyer can cancel an escrow that hasn't been funded yet", async () => {
-      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[1]});
+      hash = await MetadataStore.methods.getDataHash("U", "0x00").call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await MetadataStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U", nonce).send({from: accounts[1]});
       receipt = await Escrow.methods.cancel(receipt.events.Created.returnValues.escrowId).send({from: accounts[1]});
       let Canceled = receipt.events.Canceled;
       assert(!!Canceled, "Canceled() not triggered");

--- a/test/escrow_spec.js
+++ b/test/escrow_spec.js
@@ -69,7 +69,6 @@ config({
     },
     Escrow: {
       args: ["$SellerLicense", "$ArbitrationLicense", "$MetadataStore", "$SNT", "0x0000000000000000000000000000000000000001", feeAmount],
-      onDeploy: ["MetadataStore.methods.setEscrowAddress('$Escrow').send()"]
     },
     StandardToken: {
     }
@@ -113,9 +112,9 @@ contract("Escrow", function() {
     hash = await MetadataStore.methods.getDataHash("Iuri", "0x00", "London").call();
     signature = await web3.eth.sign(hash, accounts[0]);
 
-    receipt  = await MetadataStore.methods.addOffer(TestUtils.zeroAddress, signature, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
+    receipt  = await MetadataStore.methods.addOffer(TestUtils.zeroAddress, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
     ethOfferId = receipt.events.OfferAdded.returnValues.offerId;
-    receipt  = await MetadataStore.methods.addOffer(StandardToken.options.address, signature, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
+    receipt  = await MetadataStore.methods.addOffer(StandardToken.options.address, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
     tokenOfferId = receipt.events.OfferAdded.returnValues.offerId;
   });
 
@@ -123,10 +122,10 @@ contract("Escrow", function() {
 
     it("Seller must be licensed to participate in escrow", async () => {
       try {
-        hash = await MetadataStore.methods.getDataHash("L", [0], "U").call();
+        hash = await MetadataStore.methods.getDataHash("L", "0x00", "U").call();
         signature = await web3.eth.sign(hash, accounts[1]);
 
-        await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[8]});       
+        await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[8]});       
         assert.fail('should have reverted before');
       } catch (error) {
         assert.strictEqual(error.message, "VM Exception while processing transaction: revert Must participate in the trade");
@@ -135,10 +134,10 @@ contract("Escrow", function() {
 
     it("Buyer can create escrow", async () => {
       // receipt = await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[1]});
-      hash = await MetadataStore.methods.getDataHash("U", License.address, "L").call();
+      hash = await MetadataStore.methods.getDataHash("U", "0x00", "L").call();
       signature = await web3.eth.sign(hash, accounts[1]);
       
-      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, License.address, "L", "U").send({from: accounts[1]});      
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[1]});      
       const created = receipt.events.Created;
       assert(!!created, "Created() not triggered");
       assert.equal(created.returnValues.offerId, ethOfferId, "Invalid offerId");
@@ -147,7 +146,7 @@ contract("Escrow", function() {
 
     it("Seller should be able to create escrows", async () => {
       // receipt = await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[0]});
-      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, License.address, "L", "U").send({from: accounts[0]});
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[0]});
 
       const created = receipt.events.Created;
       assert(!!created, "Created() not triggered");
@@ -168,7 +167,7 @@ contract("Escrow", function() {
     });
 
     it("Seller should be able to fund escrow", async () => {
-      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, License.address, "L", "U").send({from: accounts[0]});
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[0]});
       escrowId = receipt.events.Created.returnValues.escrowId;
 
       // Approve fee amount
@@ -195,7 +194,7 @@ contract("Escrow", function() {
 
       await StandardToken.methods.approve(Escrow.options.address, value).send({from: accounts[0]});
 
-      receipt = await Escrow.methods.create(signature, tokenOfferId, 123, FIAT, 140, License.address, "L", "U").send({from: accounts[0]});
+      receipt = await Escrow.methods.create(signature, tokenOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[0]});
       const created = receipt.events.Created;
       assert(!!created, "Created() not triggered");
       escrowTokenId = receipt.events.Created.returnValues.escrowId;
@@ -283,7 +282,7 @@ contract("Escrow", function() {
     });
 
     it("A buyer can cancel an escrow that hasn't been funded yet", async () => {
-      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, License.address, "L", "U").send({from: accounts[1]});
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, 140, "0x00", "L", "U").send({from: accounts[1]});
       receipt = await Escrow.methods.cancel(receipt.events.Created.returnValues.escrowId).send({from: accounts[1]});
       let Canceled = receipt.events.Canceled;
       assert(!!Canceled, "Canceled() not triggered");

--- a/test/escrow_spec.js
+++ b/test/escrow_spec.js
@@ -130,7 +130,6 @@ contract("Escrow", function() {
     });
 
     it("Buyer can create escrow", async () => {
-      // receipt = await Escrow.methods.create(accounts[1], ethOfferId, 123, FIAT, 140, [0], "L", "U").send({from: accounts[1]});
       hash = await MetadataStore.methods.getDataHash("U", "0x00").call({from: accounts[1]});
       signature = await web3.eth.sign(hash, accounts[1]);
       nonce = await MetadataStore.methods.user_nonce(accounts[1]).call();

--- a/test/funding_escrows_spec.js
+++ b/test/funding_escrows_spec.js
@@ -51,9 +51,6 @@ config({
     },
     Escrow: {
       args: ["$SellerLicense", "$ArbitrationLicense", "$MetadataStore", "$SNT", "0x0000000000000000000000000000000000000001", feeAmount],
-      onDeploy: [
-        "MetadataStore.methods.setEscrowAddress('$Escrow').send()"
-      ]
     },
     StandardToken: {
     }
@@ -88,16 +85,13 @@ contract("Escrow Funding", function() {
     const encodedCall2 = ArbitrationLicense.methods.buy().encodeABI();
     await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator});
 
-    const hash = await MetadataStore.methods.getDataHash("Iuri", "0x00", "London").call();
-    const signature = await web3.eth.sign(hash, accounts[0]);
-
-    receipt  = await MetadataStore.methods.addOffer(TestUtils.zeroAddress,signature, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
+    receipt  = await MetadataStore.methods.addOffer(TestUtils.zeroAddress, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
     ethOfferId = receipt.events.OfferAdded.returnValues.offerId;
 
-    receipt  = await MetadataStore.methods.addOffer(StandardToken.options.address, signature, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
+    receipt  = await MetadataStore.methods.addOffer(StandardToken.options.address, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
     tokenOfferId = receipt.events.OfferAdded.returnValues.offerId;
 
-    receipt  = await MetadataStore.methods.addOffer(SNT.options.address, signature, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
+    receipt  = await MetadataStore.methods.addOffer(SNT.options.address, "0x00", "London", "USD", "Iuri", [0], 1, arbitrator).send({from: accounts[0]});
     SNTOfferId = receipt.events.OfferAdded.returnValues.offerId;
   });
 
@@ -130,7 +124,7 @@ contract("Escrow Funding", function() {
 
     beforeEach(async () => {
 
-      const hash = await MetadataStore.methods.getDataHash("Iuri", License.address, "London").call();
+      const hash = await MetadataStore.methods.getDataHash("Iuri", "0x00", "London").call();
       const signature = await web3.eth.sign(hash, accounts[1]);
       
       // Reset allowance

--- a/test/funding_escrows_spec.js
+++ b/test/funding_escrows_spec.js
@@ -98,10 +98,11 @@ contract("Escrow Funding", function() {
   describe("ETH as asset", async () => {
     beforeEach(async () => {
       
-      const hash = await MetadataStore.methods.getDataHash("Iuri", "0x00", "London").call();
-      const signature = await web3.eth.sign(hash, accounts[1]);
+      const hash = await MetadataStore.methods.getDataHash("Iuri", "0x00").call({from: accounts[1]});
+      const nonce = await MetadataStore.methods.user_nonce(accounts[1]).call();
+      const signature = await web3.eth.sign( hash, accounts[1]);
 
-      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, value, "0x00", "U", "12345")
+      receipt = await Escrow.methods.create(signature, ethOfferId, 123, FIAT, value, "0x00", "U", "Iuri", nonce)
                                     .send({from: accounts[0]});
 
       escrowId = receipt.events.Created.returnValues.escrowId;
@@ -123,19 +124,23 @@ contract("Escrow Funding", function() {
     let escrowIdSNT, escrowIdToken;
 
     beforeEach(async () => {
-
-      const hash = await MetadataStore.methods.getDataHash("Iuri", "0x00", "London").call();
-      const signature = await web3.eth.sign(hash, accounts[1]);
-      
       // Reset allowance
       await SNT.methods.approve(Escrow.options.address, "0").send({from: accounts[0]});
       await StandardToken.methods.approve(Escrow.options.address, "0").send({from: accounts[0]});
 
-      receipt = await Escrow.methods.create(signature, SNTOfferId, 123, FIAT, value, "0x00", "U", "12345")
+      let hash = await MetadataStore.methods.getDataHash("Iuri", "0x00").call({from: accounts[1]});
+      let signature = await web3.eth.sign(hash, accounts[1]);
+      let nonce = await MetadataStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.create(signature, SNTOfferId, 123, FIAT, value, "0x00", "U", "Iuri", nonce)
                                     .send({from: accounts[0]});
       escrowIdSNT = receipt.events.Created.returnValues.escrowId;
 
-      receipt = await Escrow.methods.create(signature, tokenOfferId, 123, FIAT, value, "0x00", "U", "12345")
+      hash = await MetadataStore.methods.getDataHash("Iuri", "0x00").call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await MetadataStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.create(signature, tokenOfferId, 123, FIAT, value, "0x00", "U", "Iuri", nonce)
                                     .send({from: accounts[0]});
       escrowIdToken = receipt.events.Created.returnValues.escrowId;
     });

--- a/test/metadata_store_spec.js
+++ b/test/metadata_store_spec.js
@@ -72,7 +72,7 @@ contract("MetadataStore", function () {
   it("should allow to add new user and offer when license owner", async function () {
     const encodedCall = SellerLicense.methods.buy().encodeABI();
     await SNT.methods.approveAndCall(SellerLicense.options.address, 10, encodedCall).send();
-    await MetadataStore.methods.addOffer(SNT.address, signature, SellerLicense.address, "London", "USD", "Iuri", [0], 1, accounts[9]).send();
+    const receipt = await MetadataStore.methods.addOffer(SNT.address, "0x00", "London", "USD", "Iuri", [0], 1, accounts[9]).send();
     const usersSize = await MetadataStore.methods.usersSize().call();
     assert.strictEqual(usersSize, '1');
     const offersSize = await MetadataStore.methods.offersSize().call();
@@ -80,7 +80,7 @@ contract("MetadataStore", function () {
   });
 
   it("should allow to add new offer only when already a user", async function () {
-    await MetadataStore.methods.addOffer(SNT.address, signature, SellerLicense.address, "London", "EUR", "Iuri", [0], 1, accounts[9]).send();
+    await MetadataStore.methods.addOffer(SNT.address, "0x00", "London", "EUR", "Iuri", [0], 1, accounts[9]).send();
     const usersSize = await MetadataStore.methods.usersSize().call();
     assert.strictEqual(usersSize, '1');
     const offersSize = await MetadataStore.methods.offersSize().call();
@@ -89,7 +89,7 @@ contract("MetadataStore", function () {
 
   it("should not allow to add new offer when margin is more than 100", async function () {
     try {
-      await MetadataStore.methods.addOffer(SNT.address, SellerLicense.address, "London", "USD", "Iuri", [0], 101, accounts[9]).send();
+      await MetadataStore.methods.addOffer(SNT.address, "0x00", "London", "USD", "Iuri", [0], 101, accounts[9]).send();
     } catch(error) {
       const usersSize = await MetadataStore.methods.usersSize().call();
       assert.strictEqual(usersSize, '1');
@@ -97,7 +97,7 @@ contract("MetadataStore", function () {
   });
 
   it("should allow to update a user and offer", async function () {
-    await MetadataStore.methods.updateOffer(0, SNT.address, SellerLicense.address, "Paris", "EUR", "Iuri", [0], 1, accounts[9]).send();
+    await MetadataStore.methods.updateOffer(0, SNT.address, "0x00", "Paris", "EUR", "Iuri", [0], 1, accounts[9]).send();
     const usersSize = await MetadataStore.methods.usersSize().call();
     assert.strictEqual(usersSize, '1');
     const user = await MetadataStore.methods.users(0).call();
@@ -117,7 +117,7 @@ contract("MetadataStore", function () {
   });
 
   it("should allow to delete an offer", async function () {
-    const receipt = await MetadataStore.methods.addOffer(SNT.address, signature, SellerLicense.address, "London", "EUR", "Iuri", [0], 1, accounts[9]).send();
+    const receipt = await MetadataStore.methods.addOffer(SNT.address, "0x00", "London", "EUR", "Iuri", [0], 1, accounts[9]).send();
     const offerAdded = receipt.events.OfferAdded;
     const offerId = offerAdded.returnValues.offerId;
 

--- a/test/metadata_store_spec.js
+++ b/test/metadata_store_spec.js
@@ -55,7 +55,7 @@ contract("MetadataStore", function () {
     const encodedCall = ArbitrationLicense.methods.buy().encodeABI();
     await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall).send({from: accounts[9]});
 
-    hash = await MetadataStore.methods.getDataHash("Iuri", SellerLicense.address, "London").call();
+    hash = await MetadataStore.methods.getDataHash("Iuri", SellerLicense.address).call();
     signature = await web3.eth.sign(hash, accounts[0]);
 
   });

--- a/test/metadata_store_spec.js
+++ b/test/metadata_store_spec.js
@@ -1,4 +1,4 @@
-/*global contract, config, it, assert, before*/
+/*global contract, config, it, assert, before, web3*/
 
 const SellerLicense = require('Embark/contracts/SellerLicense');
 const ArbitrationLicense = require('Embark/contracts/ArbitrationLicense');
@@ -45,19 +45,24 @@ config({
   accounts = web3_accounts;
 });
 
+let hash, signature;
+
 contract("MetadataStore", function () {
   before(async () => {
     await SNT.methods.generateTokens(accounts[0], 1000).send();
     await SNT.methods.generateTokens(accounts[9], 1000).send();
 
-
     const encodedCall = ArbitrationLicense.methods.buy().encodeABI();
     await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall).send({from: accounts[9]});
+
+    hash = await MetadataStore.methods.getDataHash("Iuri", SellerLicense.address, "London").call();
+    signature = await web3.eth.sign(hash, accounts[0]);
+
   });
 
   it("should not allow to add new user when not license owner", async function () {
     try {
-      await MetadataStore.methods.addOffer(SNT.address, SellerLicense.address, "London", "USD", "Iuri", [0], 1, accounts[9]).send();
+      await MetadataStore.methods.addOffer(SNT.address, signature, SellerLicense.address, "London", "USD", "Iuri", [0], 1, accounts[9]).send();
     } catch(error) {
       const usersSize = await MetadataStore.methods.usersSize().call();
       assert.strictEqual(usersSize, '0');
@@ -67,8 +72,7 @@ contract("MetadataStore", function () {
   it("should allow to add new user and offer when license owner", async function () {
     const encodedCall = SellerLicense.methods.buy().encodeABI();
     await SNT.methods.approveAndCall(SellerLicense.options.address, 10, encodedCall).send();
-    
-    await MetadataStore.methods.addOffer(SNT.address, SellerLicense.address, "London", "USD", "Iuri", [0], 1, accounts[9]).send();
+    await MetadataStore.methods.addOffer(SNT.address, signature, SellerLicense.address, "London", "USD", "Iuri", [0], 1, accounts[9]).send();
     const usersSize = await MetadataStore.methods.usersSize().call();
     assert.strictEqual(usersSize, '1');
     const offersSize = await MetadataStore.methods.offersSize().call();
@@ -76,7 +80,7 @@ contract("MetadataStore", function () {
   });
 
   it("should allow to add new offer only when already a user", async function () {
-    await MetadataStore.methods.addOffer(SNT.address, SellerLicense.address, "London", "EUR", "Iuri", [0], 1, accounts[9]).send();
+    await MetadataStore.methods.addOffer(SNT.address, signature, SellerLicense.address, "London", "EUR", "Iuri", [0], 1, accounts[9]).send();
     const usersSize = await MetadataStore.methods.usersSize().call();
     assert.strictEqual(usersSize, '1');
     const offersSize = await MetadataStore.methods.offersSize().call();
@@ -113,7 +117,7 @@ contract("MetadataStore", function () {
   });
 
   it("should allow to delete an offer", async function () {
-    const receipt = await MetadataStore.methods.addOffer(SNT.address, SellerLicense.address, "London", "EUR", "Iuri", [0], 1, accounts[9]).send();
+    const receipt = await MetadataStore.methods.addOffer(SNT.address, signature, SellerLicense.address, "London", "EUR", "Iuri", [0], 1, accounts[9]).send();
     const offerAdded = receipt.events.OfferAdded;
     const offerId = offerAdded.returnValues.offerId;
 


### PR DESCRIPTION
Stops metadata from depending on the Escrow contract.
This includes a flow change:
1. Signature is being asked in the buyer flow after the username and contact code screen.
2. Removes the redirect on the username/contact code screen, due to this signature requiring a nonce.

