### PR TITLE
fix(escrow-detail): use only two decimals to calculate the diff

### DIFF
--- a/src/js/features/escrow/actions.js
+++ b/src/js/features/escrow/actions.js
@@ -24,7 +24,7 @@ export const createEscrow = (signature, username, tradeAmount, assetPrice, statu
     escrow: {
       tradeAmount,
       offerId: offer.id,
-      assetPrice
+      assetPrice: assetPrice.toFixed(2).toString().replace('.', '')
     }
   };
 };

--- a/src/js/pages/Escrow/components/EscrowDetail.jsx
+++ b/src/js/pages/Escrow/components/EscrowDetail.jsx
@@ -9,7 +9,7 @@ import {tradeStates} from '../../../features/escrow/helpers';
 const PERCENTAGE_THRESHOLD = 10; // If asset price is 10% different than the real price, show the warning
 
 const EscrowDetail = ({escrow, currentPrice}) => {
-  const currentPriceForCurrency = parseFloat(currentPrice ? currentPrice[escrow.offer.currency] : null);
+  const currentPriceForCurrency = parseFloat(currentPrice ? currentPrice[escrow.offer.currency] : null).toFixed(2);
   const escrowAssetPrice = escrow.assetPrice / 100 * ((escrow.offer.margin / 100) + 1);
   const rateCurrentAndSellPrice = escrowAssetPrice / currentPriceForCurrency;
 
@@ -31,7 +31,7 @@ return (<Row className="mt-4">
       <p className="text-dark m-0">{(escrow.tokenAmount * escrowAssetPrice).toFixed(2)} {escrow.offer.currency} for {escrow.tokenAmount} {escrow.token.symbol}</p>
       <p className="text-dark m-0">{escrow.token.symbol} Price = {escrowAssetPrice.toFixed(2)} {escrow.offer.currency}</p>
       {escrow.expirationTime && escrow.expirationTime !== '0' && <p className="text-dark m-0">Expiration time: {moment(escrow.expirationTime * 1000).calendar()}</p>}
-      {escrow.status === tradeStates.waiting && 
+      {escrow.status === tradeStates.waiting &&
        currentPriceForCurrency && diffPercentage > PERCENTAGE_THRESHOLD &&
        <Fragment>
         <p className="text-danger font-weight-bold mb-0">The current price for {escrow.token.symbol} is {currentPriceForCurrency} {escrow.offer.currency}, which is {diffPercentage.toFixed(2)}% {isAbove ? "above" : "below"} the price for this trade</p>

--- a/src/js/wizards/Buy/1_Trade/index.jsx
+++ b/src/js/wizards/Buy/1_Trade/index.jsx
@@ -76,7 +76,7 @@ class Trade extends Component {
   }
 
   postEscrow = () => {
-    this.props.createEscrow(this.props.signature, this.props.username, this.state.assetQuantity, this.props.price.toFixed(2).toString().replace('.', ''), this.props.statusContactCode, this.props.offer, this.props.nonce);
+    this.props.createEscrow(this.props.signature, this.props.username, this.state.assetQuantity, this.props.price, this.props.statusContactCode, this.props.offer, this.props.nonce);
   };
 
   _calcPrice = () => {


### PR DESCRIPTION
I didn't get to test it a lot, because when I created a new escrow, the warning wasn't there, but this should fix it anyway