### PR TITLE
fix(network-reducer): fix updating the balance and not override

### DIFF
--- a/src/js/features/network/reducer.js
+++ b/src/js/features/network/reducer.js
@@ -51,15 +51,30 @@ function reducer(state = DEFAULT_STATE, action) {
       const balance = fromTokenDecimals(action.value, action.token.decimals);
       if (action.address && !addressCompare(action.address, state.address)) {
         return {
-          ...state, tokens: {
-            ...state.tokens, [action.token.symbol]: {
-              ...action.token, balances: {...state.tokens[action.token.symbol].balances, [action.address]: balance}
+          ...state,
+          tokens: {
+            ...state.tokens,
+            [action.token.symbol]: {
+              ...action.token,
+              balances: {
+                ...state.tokens[action.token.symbol],
+                ...state.tokens[action.token.symbol].balances,
+                [action.address]: balance
+              }
             }
           }
         };
       }
       return {
-        ...state, tokens: { ...state.tokens, [action.token.symbol]: {...action.token, balance} }
+        ...state,
+        tokens: {
+          ...state.tokens,
+          [action.token.symbol]: {
+            ...state.tokens[action.token.symbol],
+            ...action.token,
+            balance
+          }
+        }
       };
     }
     case GET_GAS_PRICE_SUCCEEDED: {


### PR DESCRIPTION
This was causing an issue where in the open trade screen, if you refreshed, it would load infinitively, because the seller balance was getting overwritten