### PR TITLE
Fix releasing SNT escrows where there is no arbitrator

### DIFF
--- a/contracts/teller-network/Fees.sol
+++ b/contracts/teller-network/Fees.sol
@@ -66,13 +66,20 @@ contract Fees is Ownable {
 
         if (_tokenAddress != address(0)) {
             ERC20Token tokenToPay = ERC20Token(_tokenAddress);
-            // Arbitrator transfer
-            require(tokenToPay.transfer(_arbitrator, arbitratorValue), "Unsuccessful token transfer - arbitrator");
+            if (_arbitrator != address(0)) {
+                require(tokenToPay.transfer(_arbitrator, arbitratorValue), "Unsuccessful token transfer - arbitrator");
+            } else {
+                destinationValue = feeAmount;
+            }
             if (destinationValue > 0) {
                 require(tokenToPay.transfer(feeDestination, destinationValue), "Unsuccessful token transfer - destination");
             }
         } else {
-            _arbitrator.transfer(arbitratorValue);
+            if (_arbitrator != address(0)) {
+                _arbitrator.transfer(arbitratorValue);
+            } else {
+                destinationValue = feeAmount;
+            }
             if (destinationValue > 0) {
                 feeDestination.transfer(destinationValue);
             }

--- a/shared.chains.json
+++ b/shared.chains.json
@@ -48,6 +48,14 @@
       "0xd0949dfc016294546a15ea6fe4c0b7e3cfd5694a7cefd629740e47baacde47d2": {
         "name": "EscrowRelay",
         "address": "0xfeB82d9fb2A3ebdF17FB3a4c11dA45f741aE479f"
+      },
+      "0x581245059f2179305333c7ece446eea99b08e0f57896241bd68a56383e8c41a5": {
+        "name": "Escrow",
+        "address": "0x000323D48EA76D43bfd3cCFDCE434645ADd7B8Ac"
+      },
+      "0x80d2b17b38faff0e57144c2b494d38954994870de3d91fc1d0363470c245a783": {
+        "name": "EscrowRelay",
+        "address": "0x6124D1039D7D3034D7742A681a67F74ACb579684"
       }
     }
   }


### PR DESCRIPTION
An escrow with no arbitrator has its address set as 0x0, but  SNT cannot be sent to 0x0, for reasons

So instead, we send everything to the fee destination (later the staking pool)