### PR TITLE
Fix wizard reseting on refresh and remove redirect on location

### DIFF
--- a/src/js/features/license/reducer.js
+++ b/src/js/features/license/reducer.js
@@ -47,7 +47,7 @@ function reducer(state = DEFAULT_STATE, action) {
       };
     case CHECK_LICENSE_OWNER:
       return {
-        ...state, licenseOwner: false
+        ...state
       };
     case CHECK_LICENSE_OWNER_SUCCEEDED:
       return {

--- a/src/js/wizards/Sell/0_Location/index.jsx
+++ b/src/js/wizards/Sell/0_Location/index.jsx
@@ -5,7 +5,6 @@ import {connect} from "react-redux";
 import DOMPurify from 'dompurify';
 
 import SellerPosition from './components/SellerPosition';
-import Loading from '../../../components/Loading';
 import newSeller from "../../../features/newSeller";
 import metadata from "../../../features/metadata";
 
@@ -13,22 +12,12 @@ class Location extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      location: props.seller.location,
-      ready: false
+      location: props.seller.location
     };
     this.validate(props.seller.location);
     this.props.footer.onPageChange(() => {
       this.props.setLocation(DOMPurify.sanitize(this.state.location));
     });
-  }
-
-  componentDidMount() {
-    if (this.props.profile && this.props.profile.location) {
-      this.props.setLocation(DOMPurify.sanitize(this.props.profile.location));
-      this.props.wizard.next();
-    } else {
-      this.setState({ready: true});
-    }
   }
 
   validate(location) {
@@ -45,10 +34,6 @@ class Location extends Component {
   };
 
   render() {
-    if (!this.state.ready) {
-      return <Loading page/>;
-    }
-
     return <SellerPosition changeLocation={this.changeLocation} location={this.state.location}/>;
   }
 }

--- a/src/js/wizards/Sell/6_Margin/components/__snapshots__/MarginSelectorForm.test.jsx.snap
+++ b/src/js/wizards/Sell/6_Margin/components/__snapshots__/MarginSelectorForm.test.jsx.snap
@@ -70,7 +70,7 @@ exports[`MarginSelectorForm should render correctly 1`] = `
         }
       >
         <InputGroup
-          className="full-width-input"
+          className="full-width-input margin-input"
           tag="div"
         >
           <Control(s)

--- a/src/js/wizards/Wizard.jsx
+++ b/src/js/wizards/Wizard.jsx
@@ -7,7 +7,8 @@ import withFooterHoC from './hoc/withFooter';
 class Wizard extends Component {
   constructor(props) {
     super(props);
-    let currentStep = props.steps.findIndex((step) => props.location.hash.endsWith(step.path));
+    const locationHash = props.location.hash || props.location.pathname;
+    let currentStep = props.steps.findIndex((step) => locationHash.endsWith(step.path));
 
     if (currentStep === -1) {
       currentStep = 0;


### PR DESCRIPTION
This probably fixes the infinite loop. 
The wizard was bugged because `hash` was empty, so the step reseted to 0 each time, now it doesn't.
We had a quick 404 on refresh in the wizard, because checking the license put `licenseOwner` to false, but it was useless.
Finally, removed the redirect on location being already present. This enables changing the location and also, redirects are dangerous.