### PR TITLE
Make Teller still work if Crypto compare is down

### DIFF
--- a/src/js/components/Offer/index.jsx
+++ b/src/js/components/Offer/index.jsx
@@ -45,7 +45,7 @@ const Offer = ({offer, offers, withDetail, prices, userAddress}) => {
           <Reputation reputation={{upCount: user.upCount, downCount: user.downCount}} size="s"/>
         </Col>
       </Row>
-      {withDetail && <Row>
+      {withDetail && prices && !prices.error && <Row>
         <Col>
           <p className="m-0">
             {offers.map((offer, index) => {

--- a/src/js/features/prices/reducer.js
+++ b/src/js/features/prices/reducer.js
@@ -6,7 +6,8 @@ function reducer(state = {}, action) {
     case FETCH_PRICES_SUCCEEDED:
       return {
         ...state,
-        ...action.data
+        ...action.data,
+        error: null
       };
     case FETCH_PRICES_FAILED:
       return {

--- a/src/js/features/prices/saga.js
+++ b/src/js/features/prices/saga.js
@@ -11,7 +11,7 @@ export function *doFetchPrices(action) {
     const data = yield call(cc.priceMulti, from, to);
     yield put({type: FETCH_PRICES_SUCCEEDED, data});
   } catch (error) {
-    yield put({type: FETCH_PRICES_FAILED, error});
+    yield put({type: FETCH_PRICES_FAILED, error: error.message});
   }
 }
 
@@ -38,7 +38,7 @@ function *fetchAllTokenPrices() {
       }
       yield put({type: FETCH_PRICES_SUCCEEDED, data});
     } catch (error) {
-      yield put({type: FETCH_PRICES_FAILED, error});
+      yield put({type: FETCH_PRICES_FAILED, error: error.message});
     }
   }
 }

--- a/src/js/features/prices/selectors.js
+++ b/src/js/features/prices/selectors.js
@@ -10,3 +10,5 @@ export const getAssetPrice = (state, assetSymbol) => {
 export const hasPrices = state => {
   return state.prices.ETH !== undefined;
 };
+
+export const error = state => state.prices.error;

--- a/src/js/locales/en.json
+++ b/src/js/locales/en.json
@@ -45,7 +45,8 @@
     "sellPrice": "Your sell price",
     "ourFee": "Our fee",
     "back": "Back",
-    "continue": "Confirm price"
+    "continue": "Confirm price",
+    "noPrice": "Unable to calculate your price since token prices are unavailable for now"
   },
   "escrowList": {
     "title": "Escrow List",

--- a/src/js/pages/Home/index.jsx
+++ b/src/js/pages/Home/index.jsx
@@ -28,9 +28,7 @@ class Home extends Component {
   }
 
   render() {
-    const t = this.props.t;
-    const hasPrices = this.props.hasPrices;
-    const isArbitrator = this.props.isArbitrator;
+    const {hasPrices, isArbitrator, t, priceError} = this.props;
 
     return (
       <div className="home">
@@ -49,8 +47,8 @@ class Home extends Component {
         <React.Fragment>
           <Row className="home--footer">
             <Col xs={6}>
-              <Button tag={Link} disabled={!hasPrices} color="primary" block to="/offers/list">
-                {hasPrices ? t('home.buy') : t('home.loadingData')}
+              <Button tag={Link} disabled={!hasPrices && !priceError} color="primary" block to="/offers/list">
+                {hasPrices || priceError ? t('home.buy') : t('home.loadingData')}
               </Button>
             </Col>
             <Col xs={6}>
@@ -89,7 +87,8 @@ const mapStateToProps = (state) => {
     isLicenseOwner: license.selectors.isLicenseOwner(state),
     isArbitrator: arbitrator.selectors.isLicenseOwner(state),
     profile: metadata.selectors.getProfile(state, address),
-    hasPrices: prices.selectors.hasPrices(state)
+    hasPrices: prices.selectors.hasPrices(state),
+    priceError: prices.selectors.error(state)
   };
 };
 

--- a/src/js/pages/Profile/components/Offer.jsx
+++ b/src/js/pages/Profile/components/Offer.jsx
@@ -21,6 +21,9 @@ const Offer = ({offer, prices, onClick, disabled}) => {
         {disabled && <UncontrolledTooltip placement="top" target={`buy-btn-${offer.id}`}>
           Offer disabled because you are the seller or the arbitrator
         </UncontrolledTooltip>}
+        {(!prices || prices.error) && <UncontrolledTooltip placement="top" target={`buy-btn-${offer.id}`}>
+          Offer disabled because we failed to fetch the token prices. Check back later.
+        </UncontrolledTooltip>}
       </Col>
 
       <NoArbitratorWarning arbitrator={offer.arbitrator} />

--- a/src/js/pages/Profile/components/Offer.jsx
+++ b/src/js/pages/Profile/components/Offer.jsx
@@ -7,23 +7,26 @@ import {calculateEscrowPrice} from '../../../utils/transaction';
 import classnames from 'classnames';
 import NoArbitratorWarning from "../../../components/NoArbitratorWarning";
 
-const Offer = ({offer, prices, onClick, disabled}) => (
-  <Row className="border py-2 mx-0 my-2 rounded">
-    <Col xs="4" className="v-align-center">
-      <p className="font-weight-bold"><img src={TokenImages[`${offer.token.symbol}.png`] || TokenImages[`generic.png`]} alt="asset icon" className="mr-2"/>{offer.token.symbol}</p>
-    </Col>
-    <Col xs="8" className="v-align-center text-right">
-      <Button color={disabled ? "secondary" : "primary" } className={classnames('p-2', {disabled, 'not-clickable': disabled})} onClick={disabled ? null : onClick} id={`buy-btn-${offer.id}`}>
-        Buy for {truncateTwo(calculateEscrowPrice(offer, prices))} {offer.currency}
-      </Button>
-      {disabled && <UncontrolledTooltip placement="top" target={`buy-btn-${offer.id}`}>
-        Offer disabled because you are the seller or the arbitrator
-      </UncontrolledTooltip>}
-    </Col>
+const Offer = ({offer, prices, onClick, disabled}) => {
+  const isDisabled = disabled || !prices || prices.error;
+  return (
+    <Row className="border py-2 mx-0 my-2 rounded">
+      <Col xs="4" className="v-align-center">
+        <p className="font-weight-bold"><img src={TokenImages[`${offer.token.symbol}.png`] || TokenImages[`generic.png`]} alt="asset icon" className="mr-2"/>{offer.token.symbol}</p>
+      </Col>
+      <Col xs="8" className="v-align-center text-right">
+        <Button color={disabled ? "secondary" : "primary" } className={classnames('p-2', {disabled: isDisabled, 'not-clickable': isDisabled})} onClick={isDisabled ? null : onClick} id={`buy-btn-${offer.id}`}>
+          Buy for {truncateTwo(calculateEscrowPrice(offer, prices))} {offer.currency}
+        </Button>
+        {disabled && <UncontrolledTooltip placement="top" target={`buy-btn-${offer.id}`}>
+          Offer disabled because you are the seller or the arbitrator
+        </UncontrolledTooltip>}
+      </Col>
 
-    <NoArbitratorWarning arbitrator={offer.arbitrator} />
-  </Row>
-);
+      <NoArbitratorWarning arbitrator={offer.arbitrator} />
+    </Row>
+  );
+};
 
 Offer.defaultProps = {
   disabled: false

--- a/src/js/utils/transaction.js
+++ b/src/js/utils/transaction.js
@@ -8,6 +8,9 @@ export const States = {
 };
 
 export const calculateEscrowPrice = (escrow, prices) => {
+  if (!prices || prices.error) {
+    return -1;
+  }
   return prices[escrow.token.symbol][escrow.currency] * ((100 + (parseFloat(escrow.margin))) / 100);
 };
 

--- a/src/js/wizards/Sell/6_Margin/components/MarginSelectorForm.jsx
+++ b/src/js/wizards/Sell/6_Margin/components/MarginSelectorForm.jsx
@@ -17,9 +17,12 @@ class MarginSelectorForm extends Component {
   render() {
     const {t, currency, margin, token, prices, feeMilliPercent} = this.props;
 
-    const basePrice = prices[token.symbol][currency];
-    const marginPrice = (margin || 0) / 100 * basePrice;
-    const calcPrice = basePrice + marginPrice;
+    let calcPrice = null;
+    if (prices && !prices.error) {
+      const basePrice = prices[token.symbol][currency];
+      const marginPrice = (margin || 0) / 100 * basePrice;
+      calcPrice = basePrice + marginPrice;
+    }
 
     return (
       <Form ref={c => {
@@ -50,10 +53,13 @@ class MarginSelectorForm extends Component {
         </FormGroup>
 
         <h3>{t('marginSelectorForm.sellPrice')}</h3>
-        <div className="border rounded p-3">
-          1 {token.symbol} = {calcPrice.toFixed(4)} {currency}
-        </div>
-        <small>{t('marginSelectorForm.priceOrigin')}</small>
+        {calcPrice !== null && <Fragment>
+          <div className="border rounded p-3">
+            1 {token.symbol} = {calcPrice.toFixed(4)} {currency}
+          </div>
+          <small>{t('marginSelectorForm.priceOrigin')}</small>
+        </Fragment>}
+        {calcPrice === null && <p>{t('marginSelectorForm.noPrice')}</p>}
 
         {(feeMilliPercent || '0') !== '0' && <Fragment>
           <h3 className="mt-4">{t('marginSelectorForm.ourFee')}</h3>


### PR DESCRIPTION
This makes us resistant against failures in fetching the prices. 

Previously, if Crypto Compare was down, the Dapp would crash in certain pages (offer list for example).

Now, we can still navigate the pages, but the prices are not shown and it's no longer possible to open a trade, until the prices come back available.