### PR TITLE
feat: allow users to go to profile page even if they don't have a profile

### DIFF
--- a/src/js/layout/App.jsx
+++ b/src/js/layout/App.jsx
@@ -133,7 +133,7 @@ class App extends Component {
         <HashRouter>
           <Container className="p-0" id="app-container">
             <NotificationManager/>
-            <Header profile={this.props.profile}/>
+            <Header />
             <div className="body-content">
               {this.props.priceError && !this.state.hidePriceError && <Alert color="danger"  toggle={this.hidePriceError}>
                 Error while fetching prices. Opening a trade will not be possible until the issue is resolved.

--- a/src/js/layout/Header/index.jsx
+++ b/src/js/layout/Header/index.jsx
@@ -9,14 +9,14 @@ import iconProfile from "../../../images/profile.svg";
 import iconCloseProfile from "../../../images/close_profile.svg";
 
 
-const Header = ({profile, location}) => (
+const Header = ({location}) => (
   <header className="border-bottom">
     <Navbar expand="md" className="px-0">
       <NavbarBrand tag={Link} to="/"><img src={logo} alt="Logo" width="32" height="32" /><span className="text-body text-logo">TN</span></NavbarBrand>
       <Nav className="ml-auto" navbar>
         <NavItem>
-          {profile && location.pathname !== '/profile' && <NavLink tag={Link} to="/profile"><img src={iconProfile} alt="Profile" width="32" height="32" /></NavLink>}
-          {profile && location.pathname === '/profile' && <NavLink tag={Link} to="/"><img src={iconCloseProfile} alt="Home" width="32" height="32" /></NavLink>}
+          {location.pathname !== '/profile' && <NavLink tag={Link} to="/profile"><img src={iconProfile} alt="Profile" width="32" height="32" /></NavLink>}
+          {location.pathname === '/profile' && <NavLink tag={Link} to="/"><img src={iconCloseProfile} alt="Home" width="32" height="32" /></NavLink>}
         </NavItem>
       </Nav>
     </Navbar>
@@ -25,7 +25,6 @@ const Header = ({profile, location}) => (
 
 Header.propTypes = {
   history: PropTypes.object,
-  profile: PropTypes.object,
   location: PropTypes.object
 };
 

--- a/src/js/pages/Arbitrators/index.jsx
+++ b/src/js/pages/Arbitrators/index.jsx
@@ -49,7 +49,7 @@ class Arbitrators extends Component {
 
     if(loading) return <Loading mining={!!txHash} txHash={txHash} />;
 
-    if(!profile.isSeller){
+    if(!profile || !profile.isSeller){
       return <NoLicense />;
     }
 

--- a/src/js/pages/MyProfile/index.jsx
+++ b/src/js/pages/MyProfile/index.jsx
@@ -81,7 +81,7 @@ class MyProfile extends Component {
 
     return (
       <Fragment>
-        <UserInformation isArbitrator={profile.isArbitrator} reputation={profile.reputation} identiconSeed={profile.statusContactCode} username={profile.username}/>
+        {profile.statusContactCode !== zeroAddress && <UserInformation isArbitrator={profile.isArbitrator} reputation={profile.reputation} identiconSeed={profile.statusContactCode} username={profile.username}/> }
         <ProfileButton linkTo="/profile/trades" image={iconTrades} title="My trades" subtitle={`${activeTrades} active`} />
         <ProfileButton linkTo="/profile/offers" image={iconOffers} title="My offers" subtitle={`${activeOffers} active`} />
         <ProfileButton linkTo="/profile/disputes" image={iconDisputes} title="Disputes" subtitle={`${openDisputes.length} active`} />


### PR DESCRIPTION
Previously there was no way for the users to become an arbitrator since the button is located in the profile, and the only way to access it was if the user already had a profile, product of being a seller or having performed a trade.

With this PR, I hide the user information panel, but still show the buttons that once clicked would request that the user acquires a license