### PR TITLE
fix: fiat price among different screens

### DIFF
--- a/contracts/teller-network/Escrow.sol
+++ b/contracts/teller-network/Escrow.sol
@@ -121,14 +121,14 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable {
      * @param _buyer Buyer Address
      * @param _offerId Offer
      * @param _tokenAmount Amount buyer is willing to trade
-     * @param _assetPrice Indicates the price of the asset in the FIAT of choice
+     * @param _fiatAmount Indicates how much FIAT will the user pay for the tokenAmount
      * @return Id of the Escrow
      */
     function _createTransaction(
         address payable _buyer,
         uint _offerId,
         uint _tokenAmount,
-        uint _assetPrice
+        uint _fiatAmount
     ) internal whenNotPaused returns(uint escrowId)
     {
         address payable seller;
@@ -142,7 +142,7 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable {
         require(sellerLicenses.isLicenseOwner(seller), "Must be a valid seller to create escrow transactions");
         require(seller != _buyer, "Seller and Buyer must be different");
         require(arbitrator != _buyer && arbitrator != address(0), "Cannot buy offers where buyer is arbitrator");
-        require(_tokenAmount != 0 && _assetPrice != 0, "Trade amounts cannot be 0");
+        require(_tokenAmount != 0 && _fiatAmount != 0, "Trade amounts cannot be 0");
 
         escrowId = transactions.length++;
 
@@ -154,7 +154,7 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable {
         trx.seller = seller;
         trx.arbitrator = arbitrator;
         trx.tokenAmount = _tokenAmount;
-        trx.assetPrice = _assetPrice;
+        trx.fiatAmount = _fiatAmount;
 
         emit Created(
             _offerId,
@@ -168,7 +168,7 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable {
      * @notice Create a new escrow
      * @param _offerId Offer
      * @param _tokenAmount Amount buyer is willing to trade
-     * @param _assetPrice Indicates the price of the asset in the FIAT of choice
+     * @param _fiatAmount Indicates how much FIAT will the user pay for the tokenAmount
      * @param _pubkeyA First coordinate of Status Whisper Public Key
      * @param _pubkeyB Second coordinate of Status Whisper Public Key
      * @param _location The location on earth
@@ -182,7 +182,7 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable {
     function createEscrow(
         uint _offerId,
         uint _tokenAmount,
-        uint _assetPrice,
+        uint _fiatAmount,
         bytes32 _pubkeyA,
         bytes32 _pubkeyB,
         string memory _location,
@@ -191,7 +191,7 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable {
         bytes memory _signature
     ) public returns(uint escrowId) {
         address payable _buyer = metadataStore.addOrUpdateUser(_signature, _pubkeyA, _pubkeyB, _location, _username, _nonce);
-        escrowId = _createTransaction(_buyer, _offerId, _tokenAmount, _assetPrice);
+        escrowId = _createTransaction(_buyer, _offerId, _tokenAmount, _fiatAmount);
     }
 
     /**
@@ -237,7 +237,7 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable {
      * @notice Create and fund a new escrow, as a seller, once you get a buyer signature
      * @param _offerId Offer
      * @param _tokenAmount Amount buyer is willing to trade
-     * @param _assetPrice Indicates the price of the asset in the FIAT of choice
+     * @param _fiatAmount Indicates how much FIAT will the user pay for the tokenAmount
      * @param _bPubkeyA First coordinate of Status Whisper Public Key
      * @param _bPubkeyB Second coordinate of Status Whisper Public Key
      * @param _bLocation The location on earth
@@ -251,7 +251,7 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable {
     function createAndFund (
         uint _offerId,
         uint _tokenAmount,
-        uint _assetPrice,
+        uint _fiatAmount,
         bytes32 _bPubkeyA,
         bytes32 _bPubkeyB,
         string memory _bLocation,
@@ -260,7 +260,7 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable {
         bytes memory _bSignature
     ) public payable returns(uint escrowId) {
         address payable _buyer = metadataStore.addOrUpdateUser(_bSignature, _bPubkeyA, _bPubkeyB, _bLocation, _bUsername, _bNonce);
-        escrowId = _createTransaction(_buyer, _offerId, _tokenAmount, _assetPrice);
+        escrowId = _createTransaction(_buyer, _offerId, _tokenAmount, _fiatAmount);
         _fund(msg.sender, escrowId);
     }
 

--- a/contracts/teller-network/EscrowRelay.sol
+++ b/contracts/teller-network/EscrowRelay.sol
@@ -84,7 +84,7 @@ contract EscrowRelay is RelayRecipient, Ownable {
    * @notice Create a new escrow
    * @param _offerId Offer
    * @param _tokenAmount Amount buyer is willing to trade
-   * @param _assetPrice Indicates the price of the asset in the FIAT of choice
+   * @param _fiatAmount Indicates how much FIAT will the user pay for the tokenAmount
    * @param _pubkeyA First coordinate of Status Whisper Public Key
    * @param _pubkeyB Second coordinate of Status Whisper Public Key
    * @param _location The location on earth
@@ -95,7 +95,7 @@ contract EscrowRelay is RelayRecipient, Ownable {
   function createEscrow(
     uint _offerId,
     uint _tokenAmount,
-    uint _assetPrice,
+    uint _fiatAmount,
     bytes32 _pubkeyA,
     bytes32 _pubkeyB,
     string memory _location,
@@ -107,7 +107,7 @@ contract EscrowRelay is RelayRecipient, Ownable {
     escrowId = escrow.createEscrow(
          _offerId,
          _tokenAmount,
-         _assetPrice,
+         _fiatAmount,
          _pubkeyA,
          _pubkeyB,
          _location,

--- a/contracts/teller-network/IEscrow.sol
+++ b/contracts/teller-network/IEscrow.sol
@@ -10,7 +10,7 @@ contract IEscrow {
       uint256 tokenAmount;
       uint256 expirationTime;
       uint256 rating;
-      uint256 assetPrice;
+      uint256 fiatAmount;
       address payable buyer;
       address payable seller;
       address payable arbitrator;
@@ -20,7 +20,7 @@ contract IEscrow {
   function createEscrow(
         uint _offerId,
         uint _tokenAmount,
-        uint _assetPrice,
+        uint _fiatAmount,
         bytes32 _pubkeyA,
         bytes32 _pubkeyB,
         string memory _location,

--- a/src/js/components/Reputation/__snapshots__/index.test.jsx.snap
+++ b/src/js/components/Reputation/__snapshots__/index.test.jsx.snap
@@ -5,13 +5,14 @@ exports[`Reputation should render correctly 1`] = `
   className="reputation-container"
 >
   <span
-    className="left-rating rounded-circle p-2"
+    className="left-rating"
   >
     1
      
     <RatingIcon
       isPositiveRating={true}
-      onClick={[Function]}
+      onClick={null}
+      size="sm"
     />
   </span>
   <span
@@ -21,7 +22,8 @@ exports[`Reputation should render correctly 1`] = `
      
     <RatingIcon
       isPositiveRating={false}
-      onClick={[Function]}
+      onClick={null}
+      size="sm"
     />
   </span>
 </span>

--- a/src/js/features/escrow/actions.js
+++ b/src/js/features/escrow/actions.js
@@ -12,7 +12,7 @@ import { toTokenDecimals } from '../../utils/numbers';
 import EscrowProxy from '../../../embarkArtifacts/contracts/EscrowProxy';
 Escrow.options.address = EscrowProxy.options.address;
 
-export const createEscrow = (signature, username, tokenAmount, assetPrice, statusContactCode, offer, nonce) => {
+export const createEscrow = (signature, username, tokenAmount, currencyQuantity, statusContactCode, offer, nonce) => {
   tokenAmount = toTokenDecimals(tokenAmount, offer.token.decimals);
   return {
     type: CREATE_ESCROW,
@@ -25,13 +25,13 @@ export const createEscrow = (signature, username, tokenAmount, assetPrice, statu
     escrow: {
       tokenAmount,
       offerId: offer.id,
-      assetPrice: assetPrice.toFixed(2).toString().replace('.', '')
+      currencyQuantity: parseFloat(currencyQuantity).toFixed(2).toString().replace('.', '')
     }
   };
 };
 
 export const fundEscrow = (escrow) => {
-  const value =toTokenDecimals(escrow.tokenAmount, escrow.token.decimals);
+  const value = toTokenDecimals(escrow.tokenAmount, escrow.token.decimals);
   return {
     type: FUND_ESCROW,
     value,

--- a/src/js/features/escrow/saga.js
+++ b/src/js/features/escrow/saga.js
@@ -36,11 +36,10 @@ const { toBN } = web3.utils;
 
 export function *createEscrow({user, escrow}) {
   const coords = generateXY(user.statusContactCode);
-
   const toSend = Escrow.methods.createEscrow(
     escrow.offerId,
     escrow.tokenAmount,
-    escrow.assetPrice,
+    escrow.currencyQuantity,
     coords.x,
     coords.y,
     '',

--- a/src/js/pages/Arbitration/components/EscrowDetail.jsx
+++ b/src/js/pages/Arbitration/components/EscrowDetail.jsx
@@ -5,8 +5,8 @@ import PropTypes from 'prop-types';
 const EscrowDetail = ({escrow}) => <Row className="mt-4">
     <Col xs="10">
       <h3>Trade details</h3>
-      <p className="m-0">{(escrow.tokenAmount * escrow.assetPrice / 100).toFixed(2)} {escrow.offer.currency} for {escrow.tokenAmount} {escrow.token.symbol}</p>
-      <p className="m-0">{escrow.token.symbol} Price = {escrow.assetPrice / 100} {escrow.offer.currency}</p>
+      <p className="m-0">{(escrow.fiatAmount / 100).toFixed(2)} {escrow.offer.currency} for {escrow.tokenAmount} {escrow.token.symbol}</p>
+      <p className="m-0">{escrow.token.symbol} Price = {((escrow.fiatAmount / 100) / escrow.tokenAmount).toFixed(4)} {escrow.offer.currency}</p>
       <p className="m-0">Took place on {escrow.createDate}</p>
     </Col>
   </Row>;

--- a/src/js/pages/Escrow/components/EscrowDetail.jsx
+++ b/src/js/pages/Escrow/components/EscrowDetail.jsx
@@ -33,9 +33,9 @@ const shouldWarn = (diff, isBuyer) => {
 
 
 const EscrowDetail = ({escrow, currentPrice, isBuyer}) => {
-  const currentPriceForCurrency = parseFloat(currentPrice ? currentPrice[escrow.offer.currency] : null).toFixed(2);
+  const currentPriceForCurrency = parseFloat(currentPrice ? currentPrice[escrow.offer.currency] : null).toFixed(4);
   const currentOfferPrice = currentPriceForCurrency * ((escrow.offer.margin / 100) + 1);
-  const escrowAssetPrice = escrow.assetPrice / 100 * ((escrow.offer.margin / 100) + 1);
+  const escrowAssetPrice = (escrow.fiatAmount / 100) / escrow.tokenAmount;
   const rateCurrentAndSellPrice = currentPriceForCurrency / escrowAssetPrice;
   const rateCurrentAndBuyerPrice = currentOfferPrice / escrowAssetPrice;
 
@@ -48,13 +48,13 @@ const EscrowDetail = ({escrow, currentPrice, isBuyer}) => {
     </Col>
     <Col xs="10">
       <h5 className="m-0">Trade details</h5>
-      <p className="text-dark m-0">{(escrow.tokenAmount * escrowAssetPrice).toFixed(2)} {escrow.offer.currency} for {escrow.tokenAmount} {escrow.token.symbol}</p>
-      <p className="text-dark m-0">{escrow.token.symbol} Price = {escrowAssetPrice.toFixed(2)} {escrow.offer.currency}</p>
+      <p className="text-dark m-0">{(escrow.fiatAmount / 100).toFixed(2)} {escrow.offer.currency} for {escrow.tokenAmount} {escrow.token.symbol}</p>
+      <p className="text-dark m-0">{escrow.token.symbol} Price = {escrowAssetPrice.toFixed(4)} {escrow.offer.currency}</p>
       {escrow.expirationTime && escrow.expirationTime !== '0' && <p className="text-dark m-0">Expiration time: {moment(escrow.expirationTime * 1000).calendar()}</p>}
 
       {escrow.status === tradeStates.waiting && isBuyer && currentPriceForCurrency && shouldWarn(buyerDiff, true) &&
        <Fragment>
-        <p className="text-danger font-weight-bold mb-0">The current price for {escrow.token.symbol} is {currentPriceForCurrency} {escrow.offer.currency}, which is {buyerDiff.diffPercentage.toFixed(2)}% {buyerDiff.isAbove ? "above" : "below"} the price for this trade ({escrowAssetPrice.toFixed(2)} {escrow.offer.currency})</p>
+        <p className="text-danger font-weight-bold mb-0">The current price for {escrow.token.symbol} is {currentPriceForCurrency} {escrow.offer.currency}, which is {buyerDiff.diffPercentage.toFixed(2)}% {buyerDiff.isAbove ? "above" : "below"} the price for this trade ({escrowAssetPrice.toFixed(4)} {escrow.offer.currency})</p>
         <p className="text-danger mb-2">Double-check whether you really want to go through with this trade</p>
       </Fragment> }
 

--- a/src/js/pages/Escrow/index.jsx
+++ b/src/js/pages/Escrow/index.jsx
@@ -168,8 +168,7 @@ class Escrow extends Component {
     const feeAmount =  tokenAmount.div(toBN(divider));
     const totalAmount = tokenAmount.add(feeAmount);
 
-    const escrowAssetPrice = escrow.assetPrice / 100 * ((escrow.offer.margin / 100) + 1);
-    const escrowFiatAmount = (escrow.tokenAmount * escrowAssetPrice).toFixed(2);
+    const escrowFiatAmount = (escrow.fiatAmount / 100).toFixed(2);
 
     const enoughBalance = toBN(escrow.token.balance ? toTokenDecimals(escrow.token.balance || 0, escrow.token.decimals) : 0).gte(totalAmount);
 

--- a/src/js/wizards/Buy/2_ConfirmTrade/index.jsx
+++ b/src/js/wizards/Buy/2_ConfirmTrade/index.jsx
@@ -30,14 +30,14 @@ class ConfirmTrade extends Component {
   }
 
   componentDidMount() {
-    if (!this.props.price || !this.props.assetQuantity) {
+    if (!this.props.price || !this.props.currencyQuantity || !this.props.assetQuantity) {
       return this.props.wizard.previous();
     }
     this.setState({ready: true});
   }
 
   postEscrow = () => {
-    this.props.createEscrow(this.props.signature, this.props.username, this.props.assetQuantity, this.props.price, this.props.statusContactCode, this.props.offer, this.props.nonce);
+    this.props.createEscrow(this.props.signature, this.props.username, this.props.assetQuantity, this.props.currencyQuantity, this.props.statusContactCode, this.props.offer, this.props.nonce);
   };
 
   cancelTrade = () => {
@@ -66,6 +66,7 @@ class ConfirmTrade extends Component {
     if (!this.state.ready || this.props.signing) {
       return <Loading page/>;
     }
+
     switch (this.props.createEscrowStatus) {
       case States.pending:
         return <Loading mining txHash={this.props.txHash}/>;
@@ -121,6 +122,10 @@ ConfirmTrade.propTypes = {
   escrowId: PropTypes.string,
   txHash: PropTypes.string,
   signing: PropTypes.bool,
+  currencyQuantity: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]),
   assetQuantity: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number
@@ -147,6 +152,7 @@ const mapStateToProps = state => {
     offer: metadata.selectors.getOfferById(state, offerId),
     nonce: metadata.selectors.getNonce(state),
     assetQuantity: newBuy.selectors.assetQuantity(state),
+    currencyQuantity: newBuy.selectors.currencyQuantity(state),
     signing: metadata.selectors.isSigning(state),
     offerId
   };

--- a/src/js/wizards/Sell/2_Currency/components/__snapshots__/FiatSelectorForm.test.jsx.snap
+++ b/src/js/wizards/Sell/2_Currency/components/__snapshots__/FiatSelectorForm.test.jsx.snap
@@ -6,6 +6,21 @@ exports[`FiatSelectorForm should render correctly 1`] = `
   <FormGroup
     tag="div"
   >
+    <Label
+      className="text-small mt-3 mb-0"
+      tag="label"
+      widths={
+        Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ]
+      }
+    >
+      Local currency
+    </Label>
     <TypeaheadContainer(WrappedTypeahead)
       a11yNumResults={[Function]}
       a11yNumSelected={[Function]}
@@ -13,7 +28,7 @@ exports[`FiatSelectorForm should render correctly 1`] = `
       allowNew={false}
       autoFocus={false}
       caseSensitive={false}
-      className="my-3"
+      className="mb-3"
       clearButton={false}
       defaultInputValue=""
       defaultOpen={false}
@@ -46,9 +61,6 @@ exports[`FiatSelectorForm should render correctly 1`] = `
       placeholder=""
       selectHintOnEnter={false}
       submitFormOnEnter={true}
-    />
-    <p
-      className="text-muted"
     />
   </FormGroup>
 </Fragment>

--- a/src/js/wizards/Sell/3_Location/components/__snapshots__/SellerPosition.test.jsx.snap
+++ b/src/js/wizards/Sell/3_Location/components/__snapshots__/SellerPosition.test.jsx.snap
@@ -2,9 +2,7 @@
 
 exports[`SellerPosition should render correctly 1`] = `
 <Fragment>
-  <h2
-    className="mb-4"
-  >
+  <h2>
     What location do you want to display
   </h2>
   <Form
@@ -13,20 +11,30 @@ exports[`SellerPosition should render correctly 1`] = `
     <FormGroup
       tag="div"
     >
+      <Label
+        className="text-small mt-3 mb-0"
+        tag="label"
+        widths={
+          Array [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+          ]
+        }
+      >
+        Location
+      </Label>
       <Input
         id="location"
         name="location"
         onChange={[Function]}
-        placeholder="City, Country"
+        placeholder="Enter location"
         type="text"
         value=""
       />
     </FormGroup>
-    <p
-      className="text-muted"
-    >
-      Enter a location to move to the next page
-    </p>
   </Form>
 </Fragment>
 `;


### PR DESCRIPTION
Since we used  2 decimal places, in the case of currencies that have a low price, we were losing precision in the calculation of prices between the buy wizard, confirmation screen and escrow page.

This changes the contract so we store the fiat amount the user is willing to pay for an amount of tokens, and then determining the asset price is done by dividing this fiat amount by the token amount. 

Additionally, I increased the number of decimals to 4 in some pages,