### PR TITLE
Add sell summary + 2 small seller fixes

### DIFF
--- a/src/js/layout/App.jsx
+++ b/src/js/layout/App.jsx
@@ -47,6 +47,7 @@ import SellArbitrator from '../wizards/Sell/5_SelectArbitrator';
 import SellCurrency from '../wizards/Sell/2_Currency';
 import SellMargin from '../wizards/Sell/6_Margin';
 import SellLimits from '../wizards/Sell/7_Limits';
+import SellSummary from '../wizards/Sell/8_Summary';
 
 // Tmp
 import SignatureContainer from '../pages/tmp/SignatureContainer';
@@ -163,7 +164,7 @@ class App extends Component {
                   {path: '/buy/contact', component: BuyContact, nextLabel: 'Sign contact info'},
                   {path: '/buy/confirm', component: BuyConfirmTrade, nextLabel: 'Confirm the trade'}
                 ]}/>
-                
+
                 <Wizard path="/sell/" steps={[
                   {path: '/sell/asset', component: SellAsset},
                   {path: '/sell/payment-methods', component: SellPaymentMethods},
@@ -172,9 +173,10 @@ class App extends Component {
                   {path: '/sell/contact', component: SellContact},
                   {path: '/sell/arbitrator', component: SellArbitrator},
                   {path: '/sell/margin', component: SellMargin},
-                  {path: '/sell/limits', component: SellLimits, nextLabel: 'Post the offer'}
+                  {path: '/sell/limits', component: SellLimits, nextLabel: 'Go to summary'},
+                  {path: '/sell/summary', component: SellSummary, nextLabel: 'Post the offer'}
                 ]}/>
-                
+
                 <Route path="/tmp/signature" component={SignatureContainer}/>
 
                 <Route component={fourOFour}/>

--- a/src/js/layout/App.jsx
+++ b/src/js/layout/App.jsx
@@ -100,6 +100,7 @@ class App extends Component {
 
   shouldComponentUpdate(nextProps, nextState) {
     return nextProps.isReady !== this.props.isReady ||
+      nextProps.isEip1102Enabled !== this.props.isEip1102Enabled ||
       !_.isEqual(nextProps.profile, this.props.profile) ||
       nextProps.error !== this.props.error ||
       nextProps.hasToken !== this.props.hasToken ||

--- a/src/js/wizards/Sell/3_Location/index.jsx
+++ b/src/js/wizards/Sell/3_Location/index.jsx
@@ -11,10 +11,11 @@ import metadata from "../../../features/metadata";
 class Location extends Component {
   constructor(props) {
     super(props);
+    const location = props.seller.location || (props.profile && props.profile.location);
     this.state = {
-      location: props.seller.location
+      location
     };
-    this.validate(props.seller.location);
+    this.validate(location);
     this.props.footer.onPageChange(() => {
       this.props.setLocation(DOMPurify.sanitize(this.state.location));
     });

--- a/src/js/wizards/Sell/4_Contact/index.jsx
+++ b/src/js/wizards/Sell/4_Contact/index.jsx
@@ -16,12 +16,14 @@ import {contactCodeRegExp} from '../../../utils/address';
 class Contact extends Component {
   constructor(props) {
     super(props);
+    const username = props.seller.username || (props.profile && props.profile.username);
+    const statusContactCode = props.seller.statusContactCode || (props.profile && props.profile.statusContactCode);
     this.state = {
-      username: props.seller.username,
-      statusContactCode: props.seller.statusContactCode,
+      username,
+      statusContactCode,
       ready: false
     };
-    this.validate(props.seller.username, props.seller.statusContactCode);
+    this.validate(username, statusContactCode);
     props.footer.onPageChange(() => {
       props.setContactInfo({username: DOMPurify.sanitize(this.state.username), statusContactCode: DOMPurify.sanitize(this.state.statusContactCode)});
     });

--- a/src/js/wizards/Sell/8_Summary/components/SellSummary.js
+++ b/src/js/wizards/Sell/8_Summary/components/SellSummary.js
@@ -1,0 +1,49 @@
+import React, {Component, Fragment} from "react";
+import PropTypes from "prop-types";
+
+import { PAYMENT_METHODS } from '../../../../features/metadata/constants';
+import Address from "../../../../components/UserInformation/Address";
+import {formatArbitratorName} from '../../../../utils/strings';
+import {compactAddress} from "../../../../utils/address";
+
+class SellSummary extends Component {
+  state = {ready: false};
+
+  formatRow(title, body) {
+    return (<Fragment>
+      <h3 className="font-weight-normal mt-3">{title}</h3>
+      <p className="mt-1 mb-1">{body}</p>
+    </Fragment>);
+  }
+
+  render() {
+    const {profile, assetData, arbitratorProfile} = this.props;
+    const {
+      statusContactCode, username, location, margin, arbitrator,
+      paymentMethods, currency, useCustomLimits, limitL, limitU
+    } = this.props.seller;
+
+    return (<Fragment>
+      <h2>Offer summary</h2>
+
+      {this.formatRow('Username', username === profile.username ? username : `${username} (used to be ${profile.username})`)}
+      {this.formatRow('Contact code', statusContactCode === profile.statusContactCode ? <Address address={statusContactCode}/> : <Fragment><Address address={statusContactCode}/> (used to be <Address address={profile.statusContactCode}/>)</Fragment>)}
+      {this.formatRow('Location', location === profile.location ? location : `${location} (used to be ${profile.location})`)}
+      {this.formatRow('Asset', assetData.symbol)}
+      {this.formatRow('Payment methods', paymentMethods.map(method => PAYMENT_METHODS[method]).join(', '))}
+      {this.formatRow('Currency', currency)}
+      {this.formatRow('Arbitrator', arbitratorProfile ? formatArbitratorName(arbitratorProfile, arbitrator, compactAddress(arbitrator, 3), 0) : <Address address={statusContactCode}/>)}
+      {this.formatRow('Margin',  `${margin}%`)}
+      {this.formatRow('Limits',  !useCustomLimits ? 'No limits' : `Between ${limitL} and ${limitU}`)}
+    </Fragment>);
+  }
+}
+
+SellSummary.propTypes = {
+  seller: PropTypes.object,
+  profile: PropTypes.object,
+  arbitratorProfile: PropTypes.object,
+  assetData: PropTypes.object
+};
+
+export default SellSummary;

--- a/src/js/wizards/Sell/8_Summary/index.jsx
+++ b/src/js/wizards/Sell/8_Summary/index.jsx
@@ -1,0 +1,110 @@
+import React, {Component, Fragment} from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import {withRouter} from "react-router-dom";
+
+import newSeller from "../../../features/newSeller";
+import metadata from "../../../features/metadata";
+import network from "../../../features/network";
+import {States} from "../../../utils/transaction";
+
+import Loading from "../../../components/Loading";
+import ErrorInformation from "../../../components/ErrorInformation";
+import Success from "../7_Limits/components/Success";
+import SellSummary from "./components/SellSummary";
+
+class Summary extends Component {
+  state = {ready: false};
+
+  componentDidMount() {
+    // TODO check limits
+    if (!(this.props.seller.useCustomLimits === false ||
+      (this.props.seller.useCustomLimits === true && this.props.seller.limitL >= 0 && this.props.seller.limitU >= 0))) {
+      return this.props.wizard.previous();
+    }
+    this.setState({ready: true});
+    this.props.footer.enableNext();
+    this.offerCreated = false;
+    this.props.footer.onNext(this.postOffer);
+  }
+
+  postOffer = () => {
+    this.props.footer.hide();
+    this.props.addOffer(this.props.seller);
+  };
+
+  continue = () => {
+    this.props.resetAddOfferStatus();
+    this.props.history.push('/offers/list');
+  };
+
+  cancel = () => {
+    this.props.resetAddOfferStatus();
+    this.props.footer.onNext(this.postOffer);
+    this.props.footer.show();
+  };
+
+  componentDidUpdate() {
+    if (this.props.addOfferStatus === States.success && !this.offerCreated) {
+      this.offerCreated = true;
+      this.props.footer.hide();
+    } else {
+      this.offerCreated = false;
+    }
+  }
+
+  render() {
+    if (!this.state.ready) {
+      return <Loading page/>;
+    }
+    switch(this.props.addOfferStatus){
+      case States.pending:
+        return <Loading mining txHash={this.props.txHash}/>;
+      case States.failed:
+        return <ErrorInformation transaction retry={this.postOffer} cancel={this.cancel}/>;
+      case States.none:
+        return <SellSummary seller={this.props.seller} profile={this.props.profile} arbitratorProfile={this.props.arbitratorProfile} assetData={this.props.assetData}/>;
+      case States.success:
+        return <Success onClick={this.continue} />;
+      default:
+        return <Fragment/>;
+    }
+  }
+}
+
+Summary.propTypes = {
+  t: PropTypes.func,
+  history: PropTypes.object,
+  addOffer: PropTypes.func,
+  setLimits: PropTypes.func,
+  seller: PropTypes.object,
+  token: PropTypes.object,
+  addOfferStatus: PropTypes.string,
+  resetAddOfferStatus: PropTypes.func,
+  wizard: PropTypes.object,
+  footer: PropTypes.object,
+  txHash: PropTypes.string,
+  profile: PropTypes.object,
+  arbitratorProfile: PropTypes.object
+};
+
+const mapStateToProps = state => {
+  const defaultAccount = network.selectors.getAddress(state);
+  const seller = newSeller.selectors.getNewSeller(state);
+  return {
+    seller: seller,
+    addOfferStatus: metadata.selectors.getAddOfferStatus(state),
+    txHash: metadata.selectors.getAddOfferTx(state),
+    profile: metadata.selectors.getProfile(state, defaultAccount),
+    arbitratorProfile: metadata.selectors.getProfile(state, seller.arbitrator),
+    assetData: network.selectors.getTokenByAddress(state, seller.asset)
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  {
+    addOffer: metadata.actions.addOffer,
+    resetAddOfferStatus: metadata.actions.resetAddOfferStatus
+  }
+)(withRouter(Summary));


### PR DESCRIPTION
- Add a summary page at the end of the create offer wizard
  - Note that it tells the user if the username, location or status code changes, to show that it changes for him/her and not the offer
- Fix the location and contact seller pages to have the profile values by default (that way, no need to write your username again)

![image](https://user-images.githubusercontent.com/11926403/67589551-a45eb980-f726-11e9-8dd4-27d9af3cdbde.png)
