### PR TITLE
feat: Adds EIP1344 to avoid replay attacks with signatures

### DIFF
--- a/contracts/teller-network/Escrow.sol
+++ b/contracts/teller-network/Escrow.sol
@@ -355,11 +355,16 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable {
      * @dev Once message is signed, pass it as _signature of pay(uint256,bytes)
      */
     function paySignHash(uint _escrowId) public view returns(bytes32){
+        uint256 cid;
+        assembly { 
+		    cid := chainid()
+		}
         return keccak256(
             abi.encodePacked(
                 address(this),
                 "pay(uint256)",
-                _escrowId
+                _escrowId,
+                cid
             )
         );
     }
@@ -640,12 +645,17 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable {
      * @dev Once message is signed, pass it as _signature of openCase(uint256,bytes)
      */
     function openCaseSignHash(uint _escrowId, uint8 _motive) public view returns(bytes32){
+        uint256 cid;
+        assembly { 
+		    cid := chainid()
+		}
         return keccak256(
             abi.encodePacked(
                 address(this),
-                "openCase(uint256)",
+                "openCase(uint256,uint8)",
                 _escrowId,
-                _motive
+                _motive,
+                cid
             )
         );
     }

--- a/contracts/teller-network/MetadataStore.sol
+++ b/contracts/teller-network/MetadataStore.sol
@@ -116,7 +116,11 @@ contract MetadataStore is Stakable, MessageSigned, SecuredFunctions {
      * @return bytes32 to sign
      */
     function _dataHash(string memory _username, string memory _contactData, uint _nonce) internal view returns (bytes32) {
-        return keccak256(abi.encodePacked(address(this), _username, _contactData, _nonce));
+        uint256 cid;
+        assembly { 
+		    cid := chainid()
+		}
+        return keccak256(abi.encodePacked(address(this), _username, _contactData, _nonce, cid));
     }
 
     /**


### PR DESCRIPTION
Adds the chain id to the values used during the hash generation, however, merging this PR will cause Embark tests to fail due to using an old version of ganache.

To fix this, 
```
uninstall ganache-cli -g
npm install ganache-cli@istanbul -g
```

Also, the error messages changed, so we need to replace `VM Exception` in the test units for `Returned error: VM Exception`

Keeping this PR in draft temporarily, but IMO it's require for a proper deployment to mainnet.
