### PR TITLE
fix: EIP1102 functionality for escrow page used when browsing the URL directly

### DIFF
--- a/src/js/features/approval/saga.js
+++ b/src/js/features/approval/saga.js
@@ -28,6 +28,8 @@ export function *onApproveToken() {
 }
 
 export function *doGetSNTAllowance() {
+  if(!web3.eth.defaultAccount) return;
+  
   try {
     const allowance = yield SNT.methods.allowance(web3.eth.defaultAccount, Escrow.options.address).call();
     yield put({type: GET_SNT_ALLOWANCE_SUCCEEDED, allowance});

--- a/src/js/features/emailNotifications/saga.js
+++ b/src/js/features/emailNotifications/saga.js
@@ -14,6 +14,8 @@ export function *checkSubscription() {
   try {
     const account = web3.eth.defaultAccount;
 
+    if(!account) return;
+
     const response = yield call(axios.get, `${EMAIL_SERVER_ENDPOINT}/user/${account}`);
     yield put({type: CHECK_EMAIL_SUBSCRIPTION_SUCCESS, subscribed: response.data.isUser});
   } catch (error) {

--- a/src/js/features/metadata/saga.js
+++ b/src/js/features/metadata/saga.js
@@ -55,6 +55,9 @@ Escrow.options.address = EscrowProxy.options.address;
 
 export function *loadUser({address}) {
   const defaultAccount = web3.eth.defaultAccount || zeroAddress;
+  
+  if(!address) return;
+
   try {
     const isArbitrator = yield ArbitrationLicense.methods.isLicenseOwner(address).call({from: defaultAccount});
     const isSeller = yield SellerLicense.methods.isLicenseOwner(address).call({from: defaultAccount});

--- a/src/js/pages/Escrow/index.jsx
+++ b/src/js/pages/Escrow/index.jsx
@@ -158,7 +158,6 @@ class Escrow extends Component {
     const isETH = escrow && addressCompare(escrow.offer.asset, zeroAddress);
     const isETHorSNT = escrow && (isETH || addressCompare(escrow.offer.asset, tokens.SNT.address));
 
-    console.log(escrow, sntAllowance, tokenAllowance);
     if (!escrow || (!sntAllowance && sntAllowance !== 0) || !arbitration || !arbitration.arbitration || (!isETHorSNT && !tokenAllowance && tokenAllowance !== 0)) {
       return <Loading page={true}/>;
     }


### PR DESCRIPTION
This is required since the email notifier has links to the escrow page instead of going to the profile.