### PR TITLE
fix: go back to buy page when last page is the profile still

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-notifications": "^1.4.3",
     "react-redux": "^6.0.0",
     "react-router-dom": "^4.3.1",
+    "react-router-last-location": "^2.0.1",
     "react-scripts": "2.1.5",
     "react-switch": "^5.0.0",
     "react-validation": "^3.0.7",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { ConnectedRouter } from "connected-react-router";
 import { Provider } from 'react-redux';
 import { I18nextProvider } from 'react-i18next';
+import { LastLocationProvider } from 'react-router-last-location';
 import i18n from './js/i18n';
 import { PersistGate } from 'redux-persist/integration/react';
 
@@ -28,9 +29,11 @@ ReactDOM.render(
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>
       <ConnectedRouter history={history}>
-        <I18nextProvider i18n={ i18n }>
-          <App />
-        </I18nextProvider>
+        <LastLocationProvider>
+          <I18nextProvider i18n={i18n}>
+            <App/>
+          </I18nextProvider>
+        </LastLocationProvider>
       </ConnectedRouter>
     </PersistGate>
   </Provider>,

--- a/src/js/layout/Header/index.jsx
+++ b/src/js/layout/Header/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Link, withRouter} from "react-router-dom";
 import {connect} from "react-redux";
 import PropTypes from 'prop-types';
+import {withLastLocation} from 'react-router-last-location';
 import {Navbar, NavbarBrand, Nav, NavLink, NavItem, Button, Row, Col} from 'reactstrap';
 import classnames from 'classnames';
 import {withTranslation} from "react-i18next";
@@ -15,7 +16,14 @@ import iconCloseProfile from "../../../images/close_profile.svg";
 
 import "./index.scss";
 
-const Header = ({t, location, history, actionNeeded}) => {
+function goBack(history, lastLocation) {
+  if (lastLocation && lastLocation.hash.includes('profile')) {
+    return history.push('/buy');
+  }
+  history.go(-1);
+}
+
+const Header = ({t, location, history, actionNeeded, lastLocation}) => {
   if (location.pathname === '/') {
     // Not this header on the landing page
     return null;
@@ -55,7 +63,7 @@ const Header = ({t, location, history, actionNeeded}) => {
                 </NavLink>}
 
                 {isProfile &&
-                <NavLink className="clickable" onClick={() => history.go(-1)}>
+                <NavLink className="clickable" onClick={() => goBack(history, lastLocation)}>
                   <img src={iconCloseProfile} alt="Home" width="32" height="32"/>
                 </NavLink>}
               </NavItem>
@@ -71,6 +79,7 @@ Header.propTypes = {
   t: PropTypes.func,
   history: PropTypes.object,
   location: PropTypes.object,
+  lastLocation: PropTypes.object,
   actionNeeded: PropTypes.bool
 };
 
@@ -78,7 +87,6 @@ const mapStateToProps = (state) => ({
   actionNeeded: escrow.selectors.actionNeeded(state) || arbitration.selectors.actionNeeded(state)
 });
 
-export default connect(
-  mapStateToProps,
-  {}
-)(withRouter(withTranslation()(Header)));
+export default withRouter(connect(
+  mapStateToProps
+)(withTranslation()(withLastLocation(Header))));

--- a/yarn.lock
+++ b/yarn.lock
@@ -15485,6 +15485,11 @@ react-router-dom@^4.3.1:
     react-router "^4.3.1"
     warning "^4.0.1"
 
+react-router-last-location@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-router-last-location/-/react-router-last-location-2.0.1.tgz#54d625876dd1448594fa1114aa02e7e21db12970"
+  integrity sha512-3FbFIWwUr2qN28vN9DNdFp6RhUH/yif6ILVff1zT+hLdyGmlNPh3GuPhveb7bHQLgB744QW8L0qtWjX58ESuZQ==
+
 react-router@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"


### PR DESCRIPTION
Change the back button in the profile page to go back to `/buy` if the last page is another `profile` page (eg settings)

Also fix a bug where going back, the X button didn't disappear. It was caused by the order of the HOCs.