### PR TITLE
Change footer to be full size Next button and Up when on desktop

### DIFF
--- a/src/css/bootstrap-overrides.scss
+++ b/src/css/bootstrap-overrides.scss
@@ -18,8 +18,7 @@
 .app-body-content {
   padding-top: 17px;
   background-color: white;
-  position: relative;
-  top: -22px;
+  margin-top: -22px;
   border-top-left-radius: 28px;
   border-top-right-radius: 28px;
 }

--- a/src/js/layout/Header/index.scss
+++ b/src/js/layout/Header/index.scss
@@ -23,7 +23,7 @@
     background-repeat: no-repeat;
     background-position: top 76% left -13px;
 
-    @media screen and (min-width: 768px) {
+    @media screen and (min-width: map-get($grid-breakpoints, "md")) {
       background-position: top 76% left 4px;
       max-width: 790px;
       padding: 12px 40px 0;
@@ -58,7 +58,7 @@
     .hamburger-nav {
       margin-top: -8px;
 
-      @media screen and (min-width: 768px) {
+      @media screen and (min-width: map-get($grid-breakpoints, "md")) {
         margin-left: 17px;
       }
     }

--- a/src/js/pages/Home/index.scss
+++ b/src/js/pages/Home/index.scss
@@ -29,7 +29,7 @@ $max-width: 750px;
     left: -231px;
     margin-top: 60px;
 
-    @media screen and (max-width: 768px) {
+    @media screen and (max-width: map-get($grid-breakpoints, "md")) {
       width: auto;
       left: 0;
     }
@@ -44,7 +44,7 @@ $max-width: 750px;
       background-size: 181px 108px;
       background-repeat: no-repeat;
 
-      @media screen and (max-width: 768px) {
+      @media screen and (max-width: map-get($grid-breakpoints, "md")) {
         display: none;
       }
     }
@@ -68,7 +68,7 @@ $max-width: 750px;
       position: relative;
       z-index: 1000;
 
-      @media screen and (max-width: 768px) {
+      @media screen and (max-width: map-get($grid-breakpoints, "md")) {
         padding: 0;
       }
     }
@@ -108,7 +108,7 @@ $max-width: 750px;
     text-align: left;
 
 
-    @media screen and (min-width: 768px) {
+    @media screen and (min-width: map-get($grid-breakpoints, "md")) {
       position: relative;
       left: -382px;
     }

--- a/src/js/wizards/hoc/withFooter.jsx
+++ b/src/js/wizards/hoc/withFooter.jsx
@@ -12,11 +12,10 @@ const Footer = (props) => {
     return null;
   }
   return (<footer className="footer">
-    {props.wizard.canPrevious() &&
-    <Button onClick={props.previous} className="m-2 p-1" color="link"><img className="fa-rotate-180 footer-arrow mr-2" src={arrow} alt="previous arrow"/> Previous</Button>}
     {props.wizard.canNext() &&
-    <Button onClick={props.next} className="float-right m-2 p-1" color="link"
-            disabled={!props.nextEnabled}>{props.nextLabel} <img  className="footer-arrow ml-2" src={props.nextEnabled ? arrow : arrowDisabled} alt="next arrow"/></Button>}
+    <Button onClick={props.next} color="primary" disabled={!props.nextEnabled}>
+      {props.nextLabel} →
+    </Button>}
   </footer>);
 };
 

--- a/src/js/wizards/hoc/withFooter.jsx
+++ b/src/js/wizards/hoc/withFooter.jsx
@@ -2,9 +2,6 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {Button} from 'reactstrap';
 
-import arrow from '../../../images/arrow.svg';
-import arrowDisabled from '../../../images/arrow-disabled.svg';
-
 import './withFooter.scss';
 
 const Footer = (props) => {

--- a/src/js/wizards/hoc/withFooter.scss
+++ b/src/js/wizards/hoc/withFooter.scss
@@ -1,6 +1,8 @@
 @import "../../../css/variable-overrides";
 
-$footer-height: 58px;
+$footer-btn-height: 44px;
+$footer-padding: 16px;
+$footer-height: $footer-btn-height + $footer-padding * 2;
 
 .container {
   position: relative;
@@ -18,8 +20,12 @@ $footer-height: 58px;
       position: fixed;
       background: #fff;
       z-index: 1000;
-      padding-top: 10px;
-      padding-bottom: 10px;
+      padding: $footer-padding;
+
+      .btn {
+        width: 100%;
+        height: $footer-btn-height;
+      }
 
       .footer-arrow {
         position: relative;

--- a/src/js/wizards/hoc/withFooter.scss
+++ b/src/js/wizards/hoc/withFooter.scss
@@ -10,6 +10,8 @@ $footer-height: $footer-btn-height + $footer-padding * 2;
   min-height: 100%;
 
   .wizard-container {
+    align-items: flex-start;
+
     .footer {
       right: 0;
       bottom: 0;
@@ -21,6 +23,13 @@ $footer-height: $footer-btn-height + $footer-padding * 2;
       background: #fff;
       z-index: 1000;
       padding: $footer-padding;
+
+      @media screen and (min-width: map-get($grid-breakpoints, "md")) {
+        position: sticky;
+        width: 100%;
+        padding: $footer-padding 0;
+        z-index: auto;
+      }
 
       .btn {
         width: 100%;


### PR DESCRIPTION
Before, we had Previous and Next, Now Next is full size and alone (easier to see)

Also, on desktop, the footer was a the very bottom, so it was annoying and hard to see, now the Footer follows the content, but sticks to the bottom of the page (`position: sticky` is very cool)

Mobile: 
![image](https://user-images.githubusercontent.com/11926403/71926385-32144780-3161-11ea-9c41-04ffcdfa4cd6.png)

Desktop:
![image](https://user-images.githubusercontent.com/11926403/71926401-3d677300-3161-11ea-90f4-56c2f53f0c95.png)

Desktop with long list (the utility of sticky):
![image](https://user-images.githubusercontent.com/11926403/71926467-638d1300-3161-11ea-88bc-7484796da27a.png)
