### PR TITLE
fix: limitH being limitU in the creation of the escrow

### DIFF
--- a/src/js/features/metadata/saga.js
+++ b/src/js/features/metadata/saga.js
@@ -236,7 +236,12 @@ export function *addOffer({user, offer}) {
     offer.margin,
     offer.arbitrator
   );
-  yield doTransaction(ADD_OFFER_PRE_SUCCESS, ADD_OFFER_SUCCEEDED, ADD_OFFER_FAILED, {user, offer, toSend, value: price});
+  yield doTransaction(ADD_OFFER_PRE_SUCCESS, ADD_OFFER_SUCCEEDED, ADD_OFFER_FAILED, {
+    user,
+    offer: Object.assign(offer, {limitH: offer.limitU}),
+    toSend,
+    value: price
+  });
 }
 
 export function *onAddOffer() {


### PR DESCRIPTION
This is something we might have to refactor more globally later. We currently handle the upper limit as both `limitH` and `limitU` (even in the contract