### PR TITLE
fix: hide footer if eip1102 gets disabled

### DIFF
--- a/src/js/wizards/Sell/0_Asset/index.jsx
+++ b/src/js/wizards/Sell/0_Asset/index.jsx
@@ -34,6 +34,9 @@ class Asset extends Component {
     if (!prevProps.isEip1102Enabled && this.props.isEip1102Enabled) {
       this.load();
       this.props.footer.show();
+    } else if (prevProps.isEip1102Enabled && !this.props.isEip1102Enabled) {
+      // Somehow became disabled
+      this.props.footer.hide();
     }
   }
 
@@ -55,7 +58,7 @@ class Asset extends Component {
   };
 
   render() {
-    return (<SellerAssets selectAsset={this.selectAsset} 
+    return (<SellerAssets selectAsset={this.selectAsset}
                           selectedAsset={this.state.selectedAsset}
                           address={this.props.address}
                           availableAssets={this.props.tokens}


### PR DESCRIPTION
Change doesn't seem to be needed, but got triggered by this: https://www.pivotaltracker.com/story/show/170643021

I'm not sure how he managed to do it, he's a bug magician!