### PR TITLE
chore: deactivate unit tests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,4 @@ install:
   - yarn install
 script:
   - yarn lint
-  - yarn test:unit
   - yarn test:contracts


### PR DESCRIPTION
Because they are useless

Once my PR in Embark is merged and we get a new nightly (tomorrow probably), we'll be able to actually rely on CI