### PR TITLE
fix: remove zero address arbitrators from offer list in selector

### DIFF
--- a/src/js/features/metadata/selectors.js
+++ b/src/js/features/metadata/selectors.js
@@ -1,5 +1,5 @@
 import {PAYMENT_METHODS} from './constants';
-import {addressCompare, toChecksumAddress} from '../../utils/address';
+import {addressCompare, toChecksumAddress, zeroAddress} from '../../utils/address';
 
 const emptyToken = {
   address: "?",
@@ -63,7 +63,7 @@ export const getOfferById = (state, id) => {
 };
 
 export const getOffersWithUser = (state) => {
-  return Object.values(state.metadata.offers).filter(x => !x.deleted).map((offer) => ({
+  return Object.values(state.metadata.offers).filter(x => !x.deleted && !addressCompare(x.arbitrator, zeroAddress)).map((offer) => ({
     ...enhanceOffer(state, offer),
     user: state.metadata.users[offer.owner] || {}
   }));

--- a/src/js/pages/Home/index.jsx
+++ b/src/js/pages/Home/index.jsx
@@ -76,11 +76,9 @@ class Home extends Component {
   };
 
   render() {
-    const {hasPrices, t, priceError, networkId, mainnetWarningShowed, prices, address} = this.props;
+    const {hasPrices, t, priceError, networkId, mainnetWarningShowed, prices, address, offers} = this.props;
 
     const loading = !hasPrices && !priceError;
-
-    const offers = this.props.offers.filter(x => !addressCompare(x.arbitrator, zeroAddress));
 
     return (
       <div className="home px-4">

--- a/src/js/pages/OffersList/index.jsx
+++ b/src/js/pages/OffersList/index.jsx
@@ -130,7 +130,7 @@ class OffersList extends Component {
   };
 
   render() {
-    let filteredOffers = this.props.offers.filter(x => !addressCompare(x.arbitrator, zeroAddress));
+    let filteredOffers = this.props.offers;
 
     if (this.state.locationCoords) {
       filteredOffers = filteredOffers.filter((offer) =>  this.calculateDistance(offer.user.coords) < 0.25);


### PR DESCRIPTION
This caused an issue in the Filter counters, because they counted offers that were not visible