### PR TITLE
fix: catch errors in getAccounts so that the saga doesn't explode

### DIFF
--- a/shared.rinkeby.json
+++ b/shared.rinkeby.json
@@ -268,6 +268,18 @@
       "0x4d0401074cd8f28f2afdb8c42cdc3e398eeab55c4d68038f4f7eb7b20ba1c330": {
         "name": "EscrowRelay",
         "address": "0x07e2D7755e4Cf203393d490a0C167c1849381913"
+      },
+      "0x5c6be61391e65c70e4719bb4bcb71283e6a920b5ee7dbf8f7da8edfc5f54fdb6": {
+        "name": "OfferStore",
+        "address": "0x689E28c0494c7f30eC853A451326a1Cb134Dbc95"
+      },
+      "0xa5edd63599edfbbb49d6ffb29ba1e6c1a048178ae86e7bdee83f9ea41849d43d": {
+        "name": "Escrow",
+        "address": "0xac133CA2fB8a095eF319214c62903945C3528243"
+      },
+      "0x0fa00ed209ca3095f4a66f9402229630ad2f7afb85e6d94b58562ba02e0254bc": {
+        "name": "EscrowRelay",
+        "address": "0x9CF40726A612Ba11c5d5E96b7e59e9142fdd8622"
       }
     }
   }

--- a/src/js/features/metadata/saga.js
+++ b/src/js/features/metadata/saga.js
@@ -137,6 +137,8 @@ export function *verifyAccountChange() {
         ));
       }
     }
+  } catch (e) {
+    console.error('Error getting accounts', e);
   } finally {
     // Interval terminated, not much to do here
   }

--- a/src/js/layout/App.jsx
+++ b/src/js/layout/App.jsx
@@ -79,8 +79,6 @@ class App extends Component {
       this.props.fetchExchangeRates();
     }, PRICE_FETCH_INTERVAL);
 
-    this.props.checkAccountChange();
-
     if (this.props.profile && this.props.profile.offers) {
       this.watchTradesForOffers();
     }
@@ -101,11 +99,15 @@ class App extends Component {
       this.props.loadOffers();
     }
     if (!prevProps.isReady && this.props.isReady && this.props.isEip1102Enabled) {
+      this.props.checkAccountChange();
       if (this.props.currentUser && this.props.currentUser !== web3.eth.defaultAccount) {
         this.props.resetState();
       }
       this.props.loadProfile(this.props.address);
       this.props.setCurrentUser(web3.eth.defaultAccount);
+    }
+    if (!prevProps.isEip1102Enabled && this.props.isEip1102Enabled && this.props.isReady) {
+      this.props.checkAccountChange();
     }
     if (!this.watchingTrades && ((!prevProps.profile && this.props.profile && this.props.profile.offers) || (prevProps.profile && !prevProps.profile.offers && this.props.profile.offers))) {
       this.watchTradesForOffers();


### PR DESCRIPTION
So, long story short, if a saga throws and is not caught, all other sagas stop working.

So the enable.ethereum still worked. Status still worked.
The reason why it worked in other browsers and not Status is because Status follows the EIP1102 spec and returns an error/throws on getAccounts if the permission is not there yet.

We fixed it in Embark, but we still had one place in Teller where we called `getAccounts` without catching and it's the `verifyAccount`.
Since it was not caught, all the other sagas in the file stopped working, that includes the `enableEthereum` one, hence why it didn't work.

You might say: `But Jonathan, the `verifyAccount` has been there for a while, why does it crash now, with the new RCs?`
I was not sure, until I remembered one thing: In the new RC, you need to re-enter your seed, so you lose all you had, including your previous permissions!
So yeah, before, when we added the `verifyAccount` everybody has already accepted the permission in Status, so `getAccounts` always worked. 
Even if you clear the cache and the button appears, Status's permission is not cleared, so in the background, you're still already approved.

Anyway, I added a catch on the `verifyAccount` and also moved the called to start verifying accounts to **after** the permission was given. 