### PR TITLE
OfferStoreV2 Upgrade Procedure (experimental)

### DIFF
--- a/contracts/common/Stakable.v2.sol
+++ b/contracts/common/Stakable.v2.sol
@@ -1,0 +1,33 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./Ownable.sol";
+import "../token/ERC20Token.sol";
+import "../token/SafeTransfer.sol";
+import "./Stakable.sol";
+
+
+
+contract StakableV2 is Stakable {
+    
+    constructor(address payable _burnAddress) public {
+        burnAddress = _burnAddress;
+    }
+
+    function _stake(uint _itemId, address payable _owner, address _tokenAddress) internal {
+        require(stakes[_itemId].owner == address(0), "Already has/had a stake");
+
+        uint stakeAmount = getAmountToStake(msg.sender);
+        require(msg.value >= stakeAmount, "More ETH is required");
+
+        stakeCounter[_owner]++;
+        // Using only ETH as stake for phase 0
+        _tokenAddress = address(0);
+
+
+        stakes[_itemId].amount = msg.value;
+        stakes[_itemId].owner = _owner;
+        stakes[_itemId].token = _tokenAddress;
+
+        emit Staked(_itemId,  _owner, stakeAmount);
+    }
+}

--- a/contracts/common/USDStakable.sol
+++ b/contracts/common/USDStakable.sol
@@ -1,14 +1,14 @@
 pragma solidity >=0.5.0 <0.6.0;
 
-import "./Stakable.sol";
+import "./Stakable.v2.sol";
 import "./Medianizer.sol";
 
 
-contract USDStakable is Stakable {
+contract USDStakable is StakableV2 {
     Medianizer public medianizer;
     uint public basePrice;
 
-    constructor(address payable _burnAddress, address _medianizer) public Stakable(_burnAddress) {
+    constructor(address payable _burnAddress, address _medianizer) public StakableV2(_burnAddress) {
         burnAddress = _burnAddress;
         basePrice = 1 ether;  // 1 usd
         medianizer = Medianizer(_medianizer);

--- a/contracts/teller-network/OfferStore.v2.sol
+++ b/contracts/teller-network/OfferStore.v2.sol
@@ -36,6 +36,7 @@ contract OfferStoreV2 is OfferStore, USDStakable {
         _initializedV2 = true;
         medianizer = Medianizer(_medianizer);
         maxOffers = 10;
+        basePrice = 1 ether;
     }
 
     event MaxOffersChanged(address sender, uint oldMax, uint newMax);

--- a/contracts/teller-network/OfferStore.v2.sol
+++ b/contracts/teller-network/OfferStore.v2.sol
@@ -1,0 +1,144 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./OfferStore.sol";
+import "../common/USDStakable.sol";
+
+/**
+* @title OfferStore
+* @dev Offers registry
+*/
+contract OfferStoreV2 is OfferStore, USDStakable {
+    bool internal _initializedV2 = false;
+    uint public maxOffers = 10;
+    mapping(address => uint) public offerCnt;
+
+    /**
+     * @param _userStore User store contract address
+     * @param _sellingLicenses Sellers licenses contract address
+     * @param _arbitrationLicenses Arbitrators licenses contract address
+     * @param _burnAddress Address to send slashed offer funds
+     * @param _medianizer DAI medianizer to obtain USD price
+     */
+    constructor(address _userStore, address _sellingLicenses, address _arbitrationLicenses, address payable _burnAddress, address _medianizer) public
+        OfferStore(_userStore, _sellingLicenses, _arbitrationLicenses, _burnAddress)
+        USDStakable(_burnAddress, _medianizer)
+    {
+        initV2(_medianizer);
+    }
+
+    /**
+     * @dev Initialize contract (used with proxy). Can only be called once
+     */
+    function initV2(
+        address _medianizer
+    ) public {
+        assert(_initializedV2 == false);
+        _initializedV2 = true;
+        medianizer = Medianizer(_medianizer);
+        maxOffers = 10;
+    }
+
+    event MaxOffersChanged(address sender, uint oldMax, uint newMax);
+
+    /**
+     * @dev Change max offers allowed per seller
+     * @param _newMax New max offers amount
+     */
+    function setMaxOffers(
+        uint _newMax
+    ) public onlyOwner {
+        emit MaxOffersChanged(msg.sender, maxOffers, _newMax);
+        maxOffers = _newMax;
+    }
+
+    /**
+    * @dev Add a new offer with a new user if needed to the list
+    * @param _asset The address of the erc20 to exchange, pass 0x0 for Eth
+    * @param _contactData Contact Data   ContactType:UserId
+    * @param _location The location on earth
+    * @param _currency The currency the user want to receive (USD, EUR...)
+    * @param _username The username of the user
+    * @param _paymentMethods The list of the payment methods the user accept
+    * @param _limitL Lower limit accepted
+    * @param _limitU Upper limit accepted
+    * @param _margin The margin for the user
+    * @param _arbitrator The arbitrator used by the offer
+    */
+    function addOffer(
+        address _asset,
+        string memory _contactData,
+        string memory _location,
+        string memory _currency,
+        string memory _username,
+        uint[] memory _paymentMethods,
+        uint _limitL,
+        uint _limitU,
+        int16 _margin,
+        address payable _arbitrator
+    ) public payable {
+        require(offerCnt[msg.sender] < maxOffers, "Exceeds the max number of offers");
+        require(arbitrationLicenses.isAllowed(msg.sender, _arbitrator), "Arbitrator does not allow this transaction");
+
+        require(_limitL <= _limitU, "Invalid limits");
+        require(msg.sender != _arbitrator, "Cannot arbitrate own offers");
+
+        userStore.addOrUpdateUser(
+            msg.sender,
+            _contactData,
+            _location,
+            _username
+        );
+
+        Offer memory newOffer = Offer(
+            _margin,
+            _paymentMethods,
+            _limitL,
+            _limitU,
+            _asset,
+            _currency,
+            msg.sender,
+            _arbitrator,
+            false
+        );
+
+        uint256 offerId = offers.push(newOffer) - 1;
+        offerWhitelist[msg.sender][offerId] = true;
+        addressToOffers[msg.sender].push(offerId);
+        offerCnt[msg.sender]++;
+
+        emit OfferAdded(
+            msg.sender,
+            offerId,
+            _asset,
+            _location,
+            _currency,
+            _username,
+            _paymentMethods,
+            _limitL,
+            _limitU,
+            _margin);
+
+        _stake(offerId, msg.sender, _asset);
+    }
+
+    /**
+     * @notice Remove user offer
+     * @dev Removed offers are marked as deleted instead of being deleted
+     * @param _offerId Id of the offer to remove
+     */
+    function removeOffer(uint256 _offerId) external {
+        require(offerWhitelist[msg.sender][_offerId], "Offer does not exist");
+
+        offers[_offerId].deleted = true;
+        offerWhitelist[msg.sender][_offerId] = false;
+        emit OfferRemoved(msg.sender, _offerId);
+
+        if(offerCnt[msg.sender] - 1 > offerCnt[msg.sender]){
+            offerCnt[msg.sender] = 0;
+        } else {
+            offerCnt[msg.sender]--;
+        }
+
+        _unstake(_offerId);
+    }
+}

--- a/contracts/teller-network/OfferStore.v2.sol
+++ b/contracts/teller-network/OfferStore.v2.sol
@@ -31,7 +31,7 @@ contract OfferStoreV2 is OfferStore, USDStakable {
      */
     function initV2(
         address _medianizer
-    ) public {
+    ) public onlyOwner {
         assert(_initializedV2 == false);
         _initializedV2 = true;
         medianizer = Medianizer(_medianizer);

--- a/embarkConfig/README_upgradeToV2.md
+++ b/embarkConfig/README_upgradeToV2.md
@@ -1,0 +1,33 @@
+### For upgrading on rinkeby:
+
+After running embark run to deploy the missing contract, execute the following in the embark console
+
+```
+OfferStore.options.address = OfferStoreProxy.options.address;
+OfferStore.methods.updateCode(OfferStoreV2.options.address).send({gas: 1000000, from: web3.eth.defaultAccount});
+OfferStoreV2.options.address = OfferStoreProxy.options.address;
+OfferStoreV2.methods.initV2(Medianizer.options.address).send({gas: 1000000, from: web3.eth.defaultAccount});
+```
+
+
+
+### For upgrading on mainnet:
+
+1. Execute `embark run` to deploy the OfferStoreV2 contract.
+2. Save the address in `contracts.json` in the `mainnet` section.
+3. Transfer the ownership of the base contract to the multisig
+```js
+OfferStoreV2.methods.transferOwnership("0x35f7C96C392cD70ca5DBaeDB2005a946A82e8a95").send({gas: 1000000, from: web3.eth.defaultAccount});
+```
+4. The following custom transactions must be executed in the multisig. To obtain the data and the contract address you need to execute the following commands in the Embark console
+  1. Upgrade code
+    - to: `OfferStoreProxy.options.address`
+    - data: `OfferStore.methods.updateCode(OfferStoreV2.options.address).encodeABI()`
+  2. Init v2
+    - to: `OfferStoreProxy.options.address`
+    - data: `OfferStoreV2.methods.initV2(Medianizer.options.address).encodeABI()`
+```
+
+Pending: verify code in etherscan
+
+

--- a/embarkConfig/README_upgradeToV2.md
+++ b/embarkConfig/README_upgradeToV2.md
@@ -1,6 +1,6 @@
 ### For upgrading on rinkeby:
 
-After running embark run to deploy the missing contract, execute the following in the embark console
+After running `embark reset` and `embark run testnet` to deploy the missing contract, execute the following in the embark console
 
 ```js
 OfferStore.options.address = OfferStoreProxy.options.address;
@@ -13,8 +13,8 @@ OfferStoreV2.methods.initV2(Medianizer.options.address).send({gas: 1000000, from
 
 ### For upgrading on mainnet:
 
-1. Execute `embark run` to deploy the OfferStoreV2 contract.
-2. Save the address in `contracts.json` in the `mainnet` section.
+1. Execute `embark reset` and `embark run livenet` to deploy the OfferStoreV2 contract.
+2. Save the address in `contracts.json` in the `mainnet` section.  
 3. Transfer the ownership of the base contract to the multisig
 ```js
 OfferStoreV2.methods.transferOwnership("0x35f7C96C392cD70ca5DBaeDB2005a946A82e8a95").send({gas: 1000000, from: web3.eth.defaultAccount});

--- a/embarkConfig/README_upgradeToV2.md
+++ b/embarkConfig/README_upgradeToV2.md
@@ -2,7 +2,7 @@
 
 After running embark run to deploy the missing contract, execute the following in the embark console
 
-```
+```js
 OfferStore.options.address = OfferStoreProxy.options.address;
 OfferStore.methods.updateCode(OfferStoreV2.options.address).send({gas: 1000000, from: web3.eth.defaultAccount});
 OfferStoreV2.options.address = OfferStoreProxy.options.address;

--- a/embarkConfig/contracts.js
+++ b/embarkConfig/contracts.js
@@ -63,6 +63,9 @@ module.exports = {
 
       },
       OfferStore: {
+        args: ["$UserStore", "$SellerLicense", "$ArbitrationLicense", BURN_ADDRESS]
+      },
+      OfferStoreV2: {
         args: ["$UserStore", "$SellerLicense", "$ArbitrationLicense", BURN_ADDRESS, "$Medianizer"]
       },
       UserStoreProxy: {
@@ -84,7 +87,7 @@ module.exports = {
         deps: ['RelayHub']
       },
       Escrow: {
-        args: ["$accounts[0]", FALLBACK_ARBITRATOR, "$ArbitrationLicense", "$OfferStore", "$UserStore", "$KyberFeeBurner", FEE_MILLI_PERCENT]
+        args: ["$accounts[0]", FALLBACK_ARBITRATOR, "$ArbitrationLicense", "$OfferStoreV2", "$UserStore", "$KyberFeeBurner", FEE_MILLI_PERCENT]
       },
       EscrowProxy: {
         instanceOf: "Proxy",

--- a/embarkConfig/contracts.js
+++ b/embarkConfig/contracts.js
@@ -4,7 +4,7 @@ const FEE_MILLI_PERCENT = "1000"; // 1 percent
 const BURN_ADDRESS = "0x0000000000000000000000000000000000000002";
 const MAINNET_OWNER = "0x35f7C96C392cD70ca5DBaeDB2005a946A82e8a95";
 const FALLBACK_ARBITRATOR = "0x35f7C96C392cD70ca5DBaeDB2005a946A82e8a95";
-const GAS_PRICE = "5000000000"; //5 gwei
+const GAS_PRICE = "1000000000"; //5 gwei
 
 // TODO: extract this to .env?
 
@@ -236,6 +236,9 @@ module.exports = {
       },
       OfferStore: {
         address: "0xe7d367bd57e8457e23f0432fc84b3beaab41cad1"
+      },
+      OfferStoreV2: {
+        address: "0x5EaE5D9Fc2F38d18D9F3Bfa584700801850670D0"
       },
       UserStoreProxy: {
         instanceOf: "Proxy",

--- a/embarkConfig/data.js
+++ b/embarkConfig/data.js
@@ -103,8 +103,7 @@ module.exports = async (gasPrice, licensePrice, arbitrationLicensePrice, feeMill
         deps.contracts.UserStore.options.address,
         deps.contracts.SellerLicenseProxy.options.address,
         deps.contracts.ArbitrationLicenseProxy.options.address,
-        burnAddress,
-        deps.contracts.Medianizer.options.address
+        burnAddress
       ));
       console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
     }


### PR DESCRIPTION
### For upgrading on rinkeby:

 After running `embark reset` and `embark run testnet` to deploy the missing contract, execute the following in the embark console

 ```js
OfferStore.options.address = OfferStoreProxy.options.address;
OfferStore.methods.updateCode(OfferStoreV2.options.address).send({gas: 1000000, from: web3.eth.defaultAccount});
OfferStoreV2.options.address = OfferStoreProxy.options.address;
OfferStoreV2.methods.initV2(Medianizer.options.address).send({gas: 1000000, from: web3.eth.defaultAccount});
```



 ### For upgrading on mainnet:

 1. Execute `embark reset` and `embark run livenet` to deploy the OfferStoreV2 contract.
2. Save the address in `contracts.json` in the `mainnet` section.  
3. Transfer the ownership of the base contract to the multisig
```js
OfferStoreV2.methods.transferOwnership("0x35f7C96C392cD70ca5DBaeDB2005a946A82e8a95").send({gas: 1000000, from: web3.eth.defaultAccount});
```
4. The following custom transactions must be executed in the multisig. To obtain the data and the contract address you need to execute the following commands in the Embark console
  1. Upgrade code
    - to: `OfferStoreProxy.options.address`
    - data: `OfferStore.methods.updateCode(OfferStoreV2.options.address).encodeABI()`
  2. Init v2
    - to: `OfferStoreProxy.options.address`
    - data: `OfferStoreV2.methods.initV2(Medianizer.options.address).encodeABI()`
```
 Pending: verify code in etherscan
