### PR TITLE
feat: allow specifying a timeout for arbitrators and escalating a dispute to the fallback arbitrator once the timeout passes.

### DIFF
--- a/contracts/teller-network/Escrow.sol
+++ b/contracts/teller-network/Escrow.sol
@@ -94,9 +94,23 @@ contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable, Proxiable
         feeDestination = _feeDestination;
         feeMilliPercent = _feeMilliPercent;
         paused = false;
+        arbitrationTimeout = 5 days;
+
         _setOwner(msg.sender);
     }
+    
+    /**
+     * @dev Update arbitration timeout. Can only be called by owner
+     * @param _newTimeout new timeout in seconds
+     */
+    function updateArbitrationTimeout(uint _newTimeout) public onlyOwner {
+        arbitrationTimeout = _newTimeout;
+    }
 
+    /**
+     * @dev Update proxy implementation. Can only be called by owner
+     * @param _newCode New contract implementation address
+     */
     function updateCode(address newCode) public onlyOwner {
         updateCodeAddress(newCode);
     }


### PR DESCRIPTION
This change allows anyone to call the `escalateDispute` function on an escrow to automatically assign the dispute to the fallback arbitrator. We can then add in the escrow page an action for the users to call this function once the timeout date is reached.