### PR TITLE
feat: update to new crypto icon library which has the DAI icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "clone-deep": "^4.0.1",
     "connected-react-router": "^6.8.0",
     "cryptocompare": "^1.0.0",
-    "cryptocurrency-icons": "^0.16.1",
+    "cryptocurrency-icons": "embarklabs/cryptocurrency-icons#0.16.2",
     "css-loader": "^3.4.2",
     "dompurify": "^2.0.8",
     "elliptic": "^6.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5819,10 +5819,9 @@ cryptocompare@^1.0.0:
   resolved "https://registry.yarnpkg.com/cryptocompare/-/cryptocompare-1.0.0.tgz#d93bafd037686ec13bbf3cf6b40187310f991a3d"
   integrity sha512-Xk6+hJJ+XSlWsofIx2WHF2n410ADLkXMfCn/1aLTI4NlWLo2LPtQzw+j3aBEPQ+HVar1dO5HVLAJFBQqGyhdOQ==
 
-cryptocurrency-icons@^0.16.1:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/cryptocurrency-icons/-/cryptocurrency-icons-0.16.1.tgz#33ec0b828c666f773b53866b4b803b2a06c28efc"
-  integrity sha512-C6y+r56g0ZJzZ9kCbeKa/WXb/oz1elilsaSGjv86T93P0oZWr4v5pxnbtZrEnvHn63qbTxo/Pz3NvzLbKrnQVQ==
+cryptocurrency-icons@embarklabs/cryptocurrency-icons#0.16.2:
+  version "0.16.2"
+  resolved "https://codeload.github.com/embarklabs/cryptocurrency-icons/tar.gz/6a266ee97c5f11d838a380af7e777965b88c8d8b"
 
 csextends@^1.0.3:
   version "1.2.0"


### PR DESCRIPTION
I forked the original library and added the icon. I didn't add the PNG version, but we don't need it so whatever.

![image](https://user-images.githubusercontent.com/11926403/77795023-3efb5580-7043-11ea-90fc-493d865876a1.png)
