### PR TITLE
fix use of legacy get.status.im domain

### DIFF
--- a/SWARM.md
+++ b/SWARM.md
@@ -18,7 +18,7 @@ contributors:
 
 ## Communication
 (required)
-`status channel (same as swarm id)`: [#000-foobar](https://get.status.im/chat/public/000-foobar)
+`status channel (same as swarm id)`: [#000-foobar](https://join.status.im/000-foobar)
 `sync frequency`: Weekly Sync
 
 TODO

--- a/src/js/pages/Arbitration/components/ContactUser.jsx
+++ b/src/js/pages/Arbitration/components/ContactUser.jsx
@@ -21,7 +21,7 @@ const ContactUser = ({t, isStatus, userInfo, isBuyer, onClick}) => {
   </Row>;
 
   if (isStatus && userContactObject.method === 'Status') {
-    return <a href={"https://get.status.im/user/" + userContactObject.userId}
+    return <a href={"https://join.status.im/u/" + userContactObject.userId}
               rel="noopener noreferrer" target="_blank">{button}</a>;
   }
 

--- a/src/js/pages/Escrow/components/EscrowDetail.jsx
+++ b/src/js/pages/Escrow/components/EscrowDetail.jsx
@@ -78,7 +78,7 @@ const EscrowDetail = ({t, escrow, currentPrice, isBuyer, arbitrationDetails, onC
         </Col>
         <Col xs={3} className="pt-3">
           {isStatus && otherUserContactObj.method === 'Status' &&
-          <a href={"https://get.status.im/user/" + otherUserContactObj.userId}
+          <a href={"https://join.status.im/u/" + otherUserContactObj.userId}
              rel="noopener noreferrer" target="_blank" className="btn btn-primary btn-sm">
             {t('escrow.openChat.chat')}
           </a>}


### PR DESCRIPTION
We've replaced https://get.status.im/ with https://join.status.im/ for deep links.